### PR TITLE
UILIC-4: Remove actionMenuItems-prop from <Pane>

### DIFF
--- a/src/components/Licenses/ViewLicense/ViewLicense.js
+++ b/src/components/Licenses/ViewLicense/ViewLicense.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 
@@ -8,6 +8,7 @@ import {
   Layout,
   Pane,
   Layer,
+  Button,
 } from '@folio/stripes/components';
 
 import {
@@ -17,7 +18,6 @@ import {
 import EditLicense from '../EditLicense';
 
 class ViewLicense extends React.Component {
-
   static manifest = Object.freeze({
     selectedLicense: {
       type: 'okapi',
@@ -33,6 +33,11 @@ class ViewLicense extends React.Component {
     paneWidth: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     stripes: PropTypes.object,
   };
+
+  constructor(props) {
+    super(props);
+    this.getActionMenu = this.getActionMenu.bind(this);
+  }
 
   state = {
     sections: {
@@ -100,11 +105,63 @@ class ViewLicense extends React.Component {
     );
   }
 
+  getActionMenu({ onToggle }) {
+    const { onEdit, editLink, stripes: { hasPerm, intl } } = this.props;
+    const items = [];
+
+    /**
+     * Can edit
+     */
+    if (hasPerm('ui-licenses.licenses.edit')) {
+      items.push({
+        id: 'clickable-edit-license',
+        label: intl.formatMessage({ id: 'ui-licenses.licenses.edit' }),
+        ariaLabel: intl.formatMessage({ id: 'ui-licenses.licenses.editLicense' }),
+        href: editLink,
+        onClick: onEdit,
+        icon: 'edit',
+      });
+    }
+
+    /**
+     * We only want to render the action menu
+     * if we have something to show
+     */
+    if (!items.length) {
+      return null;
+    }
+
+    /**
+     * Return action menu
+     */
+    return (
+      <Fragment>
+        {items.map((item, index) => (
+          <Button
+            key={index}
+            buttonStyle="dropdownItem"
+            id={item.id}
+            aria-label={item.ariaLabel}
+            href={item.href}
+            onClick={() => {
+              // Toggle the action menu dropdown
+              onToggle();
+              item.onClick();
+            }}
+          >
+            <Icon icon={item.icon}>
+              {item.label}
+            </Icon>
+          </Button>
+        ))}
+      </Fragment>
+    );
+  }
+
   render() {
     const license = this.getLicense();
     if (!license) return this.renderLoadingPane();
 
-    const { stripes } = this.props;
     const sectionProps = this.getSectionProps();
 
     return (
@@ -114,14 +171,7 @@ class ViewLicense extends React.Component {
         paneTitle={license.name}
         dismissible
         onClose={this.props.onClose}
-        actionMenuItems={stripes.hasPerm('ui-licenses.licenses.edit') ? [{
-          id: 'clickable-edit-license',
-          title: stripes.intl.formatMessage({ id: 'ui-licenses.licenses.editLicense' }),
-          label: stripes.intl.formatMessage({ id: 'ui-licenses.licenses.edit' }),
-          href: this.props.editLink,
-          onClick: this.props.onEdit,
-          icon: 'edit',
-        }] : []}
+        actionMenu={this.getActionMenu}
       >
         <AccordionSet>
           <LicenseInfo id="licenseInfo" open={this.state.sections.licenseInfo} {...sectionProps} />


### PR DESCRIPTION
Removed the 'actionMenuItems'-prop from Pane and replaced it with the new 'actionMenu'-prop.

**Issue:** https://issues.folio.org/browse/UILIC-4

This is a part of: https://issues.folio.org/browse/STCOM-405

**Note:** I was not able to run ui-licenses on my local dev setup so I did not test these changes locally.