### PR TITLE
Add dependency on Okapi interface "licenses" version "1.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "home": "/licenses",
     "hasSettings": true,
     "queryResource": "query",
-    "okapiInterfaces": {},
+    "okapiInterfaces": {
+      "licenses": "1.0"
+    },
     "permissionSets": [
       {
         "permissionName": "module.licenses.enabled",


### PR DESCRIPTION
This will allow Okapi to pull in the required backend module to provide the "licenses" interface. Requesting review, as there may be a reason why this wasn't included in the first place.

Towards UILIC-7.