### PR TITLE
Remove lookbehinds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.0.0 IN PROGRESS
 * Upgrade to Stripes 2.0
+* Removed usage of lookbehinds in regexes (avail in 2.0.1)
 
 ## 1.1.0
 First Official Release for Q4 Release - 2018-12-11

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/licenses",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "License functionality for Stripes",
   "main": "src/index.js",
   "repository": "",

--- a/src/components/ViewLicense/Sections/LicenseCustomProperties.js
+++ b/src/components/ViewLicense/Sections/LicenseCustomProperties.js
@@ -12,12 +12,12 @@ export default class LicenseCustomProperties extends React.Component {
   };
 
   renderPropertyName = (propName) => {
-    const afterLowercase = /(?<=[a-z])([A-Z])/gm;
-    const afterCapsBeforeLowercase = /(?<=[A-Z])([A-Z])(?=[a-z])/gm;
+    const afterLowercase = /([a-z])([A-Z])/gm;
+    const afterCapsBeforeLowercase = /([A-Z])([A-Z])([a-z])/gm;
 
     let formattedName = propName
-      .replace(afterLowercase, ' $1')
-      .replace(afterCapsBeforeLowercase, ' $1')
+      .replace(afterLowercase, '$1 $2')
+      .replace(afterCapsBeforeLowercase, '$1 $2$3')
       .replace('_', ' ');
 
     formattedName = formattedName.charAt(0).toUpperCase() + formattedName.slice(1);


### PR DESCRIPTION
Lookbehinds [aren't available in non-Chrome browsers yet](http://kangax.github.io/compat-table/es2016plus/) and apparently we aren't polyfilling/transpiling them.

This rewrites our usage of lookbehinds.