### PR TITLE
ERM-12 Added ability to filter licenses by status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 2.0.0 IN PROGRESS
 * Upgrade to Stripes 2.0
 * Removed usage of lookbehinds in regexes (avail in 2.0.1)
+* Added License Status filter to search.
 
 ## 1.1.0
 First Official Release for Q4 Release - 2018-12-11

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "type": "app",
     "displayName": "ui-licenses.meta.title",
     "route": "/licenses",
-    "home": "/licenses",
+    "home": "/licenses?sort=Name&filters=status.Active",
     "hasSettings": true,
     "queryResource": "query",
     "okapiInterfaces": {

--- a/src/components/LicenseFilters/LicenseFilters.js
+++ b/src/components/LicenseFilters/LicenseFilters.js
@@ -1,0 +1,77 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { get } from 'lodash';
+import { FormattedMessage } from 'react-intl';
+
+import { Accordion, AccordionSet, FilterAccordionHeader } from '@folio/stripes/components';
+import { CheckboxFilter } from '@folio/stripes/smart-components';
+
+const FILTERS = [
+  'status',
+];
+
+export default class LicenseFilters extends React.Component {
+  static propTypes = {
+    activeFilters: PropTypes.object,
+    onChange: PropTypes.func.isRequired,
+    resources: PropTypes.object.isRequired,
+  };
+
+  static defaultProps = {
+    activeFilters: {
+      status: [],
+    }
+  };
+
+  state = {
+    status: [],
+  }
+
+  static getDerivedStateFromProps(props, state) {
+    const newState = {};
+
+    FILTERS.forEach(filter => {
+      const values = get(props.resources, [`${filter}Values`, 'records'], []);
+      if (values.length !== state[filter].length) {
+        newState[filter] = values.map(({ label }) => ({ label, value: label }));
+      }
+    });
+
+    if (Object.keys(newState).length) return newState;
+
+    return null;
+  }
+
+  createClearFilterHandler = (name) => () => {
+    this.props.onChange({ name, values: [] });
+  }
+
+  renderCheckboxFilter = (name, props) => {
+    const activeFilters = this.props.activeFilters[name] || [];
+
+    return (
+      <Accordion
+        displayClearButton={activeFilters.length > 0}
+        header={FilterAccordionHeader}
+        label={<FormattedMessage id={`ui-licenses.prop.${name}`} />}
+        onClearFilter={() => { this.props.onChange({ name, values: [] }); }}
+        {...props}
+      >
+        <CheckboxFilter
+          dataOptions={this.state[name]}
+          name={name}
+          onChange={this.props.onChange}
+          selectedValues={activeFilters}
+        />
+      </Accordion>
+    );
+  }
+
+  render() {
+    return (
+      <AccordionSet>
+        {this.renderCheckboxFilter('status')}
+      </AccordionSet>
+    );
+  }
+}

--- a/src/components/LicenseFilters/index.js
+++ b/src/components/LicenseFilters/index.js
@@ -1,0 +1,1 @@
+export { default } from './LicenseFilters';

--- a/src/routes/Licenses.js
+++ b/src/routes/Licenses.js
@@ -5,8 +5,9 @@ import { SearchAndSort } from '@folio/stripes/smart-components';
 import getSASParams from '../util/getSASParams';
 import packageInfo from '../../package';
 
-import ViewLicense from '../components/ViewLicense';
 import EditLicense from '../components/EditLicense';
+import LicenseFilters from '../components/LicenseFilters';
+import ViewLicense from '../components/ViewLicense';
 
 const INITIAL_RESULT_COUNT = 100;
 
@@ -18,21 +19,59 @@ export default class Licenses extends React.Component {
       path: 'licenses/licenses',
       params: getSASParams({
         searchKey: 'name',
+        columnMap: {
+          'Name': 'name',
+          'Description': 'description',
+        }
       })
     },
-    query: {},
+    statusValues: {
+      type: 'okapi',
+      path: 'licenses/refdata/License/status',
+    },
+    query: { initialValue: {} },
     resultCount: { initialValue: INITIAL_RESULT_COUNT },
+    selectedLicenseId: { initialValue: '' },
   });
 
   static propTypes = {
     resources: PropTypes.shape({
-      records: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.object), PropTypes.object]),
+      query: PropTypes.object,
+      records: PropTypes.object,
+      statusValues: PropTypes.object,
     }),
     mutator: PropTypes.object,
     onSelectRow: PropTypes.func,
+    browseOnly: PropTypes.bool,
   };
 
-  create = (license) => {
+  state = {
+    activeFilters: [],
+  }
+
+  handleFilterChange = ({ name, values }) => {
+    this.setState((prevState) => ({
+      activeFilters: {
+        ...prevState.activeFilters,
+        [name]: values,
+      }
+    }), () => {
+      const { activeFilters } = this.state;
+
+      const filters = Object.keys(activeFilters)
+        .map((filterName) => {
+          return activeFilters[filterName]
+            .map((filterValue) => `${filterName}.${filterValue}`)
+            .join(',');
+        })
+        .filter(filter => filter)
+        .join(',');
+
+      this.props.mutator.query.update({ filters });
+    });
+  }
+
+  handleCreate = (license) => {
     const { mutator } = this.props;
 
     mutator.records.POST(license)
@@ -44,24 +83,44 @@ export default class Licenses extends React.Component {
       });
   };
 
+  getActiveFilters = () => {
+    const { query } = this.props.resources;
+
+    if (!query || !query.filters) return undefined;
+
+    return query.filters
+      .split(',')
+      .reduce((filterMap, currentFilter) => {
+        const [name, value] = currentFilter.split('.');
+
+        if (!Array.isArray(filterMap[name])) {
+          filterMap[name] = [];
+        }
+
+        filterMap[name].push(value);
+        return filterMap;
+      }, {});
+  }
+
+  renderFilters = (onChange) => {
+    return (
+      <LicenseFilters
+        activeFilters={this.getActiveFilters()}
+        onChange={onChange}
+        resources={this.props.resources}
+      />
+    );
+  }
+
   render() {
-    // II Copied from ../ui-users/src/Users.js - I have no idea which of these might be needed for other things, or where this list
-    // is defined, so leaving it here in full, along with the signpost to Users.js to try and help the next lost soul who finds themselves here.
-    const { onSelectRow } = this.props;
-
-    const path = '/licenses';
-    packageInfo.stripes.route = path;
-    packageInfo.stripes.home = path;
-
     return (
       <SearchAndSort
+        browseOnly={this.props.browseOnly}
         columnMapping={{
-          id: 'ID',
           name: 'Name',
           description: 'Description'
         }}
         columnWidths={{
-          id: 300,
           name: 300,
           description: 'auto',
         }}
@@ -71,11 +130,13 @@ export default class Licenses extends React.Component {
         key="licenses"
         newRecordPerms="module.licenses.enabled"
         objectName="title"
-        onCreate={this.create}
-        onSelectRow={onSelectRow}
+        onCreate={this.handleCreate}
+        onFilterChange={this.handleFilterChange}
+        onSelectRow={this.props.onSelectRow}
         packageInfo={packageInfo}
         parentMutator={this.props.mutator}
         parentResources={this.props.resources}
+        renderFilters={this.renderFilters}
         resultCountIncrement={INITIAL_RESULT_COUNT}
         showSingleResult
         viewRecordComponent={ViewLicense}

--- a/translations/ui-licenses/en.json
+++ b/translations/ui-licenses/en.json
@@ -18,6 +18,8 @@
   "licenses.customProperties": "License Properties",
   "licenses.editLicense": "Edit License",
   "licenses.updateLicense": "Update License",
-  "licenses.createLicense": "Create License"
+  "licenses.createLicense": "Create License",
+
+  "prop.status": "Status"
 }
 


### PR DESCRIPTION
- Implemented using [`SearchAndSort`'s new `renderFilters` and `onFilterChange` props](https://github.com/folio-org/stripes-smart-components/tree/master/lib/SearchAndSort) since we'll be using complex filter components eventually.
- `LicenseFilters` is where we'll be adding new filters in the future. This approach parallels `AgreementFilters` in `ui-agreements`.
- Available values for the status are fetched by `Licenses` via the `licenses/refdata/License/status` endpoint.
- `package.json` updated to apply a default filter set of showing only licenses with an `Active` status.