### PR TITLE
ERM-1 & ERM-11 License CRUD Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "start": "stripes serve",
     "build": "stripes build --output ./output",
-    "test": "stripes test nightmare --run demo --show",
+    "test": "stripes test nightmare --run crud",
+    "test-crud": "stripes test nightmare --run crud",
     "lint": "eslint src"
   },
   "devDependencies": {

--- a/src/components/EditLicense/EditLicense.js
+++ b/src/components/EditLicense/EditLicense.js
@@ -101,4 +101,5 @@ export default stripesForm({
   validate,
   navigationCheck: true,
   enableReinitialize: true,
+  keepDirtyOnReinitialize: true,
 })(EditLicense);

--- a/src/components/LicenseFilters/LicenseFilters.js
+++ b/src/components/LicenseFilters/LicenseFilters.js
@@ -51,6 +51,7 @@ export default class LicenseFilters extends React.Component {
 
     return (
       <Accordion
+        id={`filter-accordion-${name}`}
         displayClearButton={activeFilters.length > 0}
         header={FilterAccordionHeader}
         label={<FormattedMessage id={`ui-licenses.prop.${name}`} />}

--- a/src/components/ViewLicense/Sections/LicenseInfo.js
+++ b/src/components/ViewLicense/Sections/LicenseInfo.js
@@ -35,7 +35,7 @@ class LicenseInfo extends React.Component {
         <Row>
           <Col xs={12}>
             <KeyValue label={<FormattedMessage id="ui-licenses.prop.name" />}>
-              <div data-test-license-description>
+              <div data-test-license-name>
                 {license.name}
               </div>
             </KeyValue>

--- a/src/routes/Licenses.js
+++ b/src/routes/Licenses.js
@@ -113,7 +113,11 @@ export default class Licenses extends React.Component {
       const endDate = new Date(values.endDate);
 
       if (startDate >= endDate) {
-        errors.endDate = <FormattedMessage id="ui-licenses.errors.endDateGreaterThanStartDate" />;
+        errors.endDate = (
+          <div data-test-error-end-date-too-early>
+            <FormattedMessage id="ui-licenses.errors.endDateGreaterThanStartDate" />
+          </div>
+        );
       }
     }
 

--- a/test/ui-testing/crud.js
+++ b/test/ui-testing/crud.js
@@ -1,0 +1,196 @@
+/* global describe, it, before, after, Nightmare */
+
+const generateLicenseValues = () => {
+  const number = Math.round(Math.random() * 100000);
+  return {
+    name: `Fledgling License #${number}`,
+    description: `This license of count #${number} is still in its initial stages.`,
+    type: 'Alliance',
+    status: 'In Negotiation',
+    startDate: '2020-01-01',
+    endDate: '2020-01-11',
+
+    editedName: `Edited License #${number}`,
+    editedType: 'National',
+    editedStatus: 'Active',
+  };
+};
+
+const createLicense = (nightmare, done, defaultValues, resourceId) => {
+  const values = defaultValues || generateLicenseValues();
+
+  nightmare
+    .wait('#clickable-licenses-module')
+    .click('#clickable-licenses-module')
+    .wait('#licenses-module-display')
+    .wait('#clickable-newlicense')
+    .click('#clickable-newlicense')
+
+    .waitUntilNetworkIdle(2000) // Wait for the default values to be fetched and set.
+
+    .insert('#edit-license-name', values.name)
+
+    .type('#edit-license-type', values.type)
+    .type('#edit-license-status', values.status)
+
+    .insert('#edit-license-start-date', values.startDate)
+    .insert('#edit-license-end-date', values.endDate)
+
+    .insert('#edit-license-description', values.description)
+
+    .click('#clickable-createlicense')
+    .wait('#licenseInfo')
+    .waitUntilNetworkIdle(500)
+    .evaluate(expectedValues => {
+      const foundName = document.querySelector('[data-test-license-name]').innerText;
+      if (foundName !== expectedValues.name) {
+        throw Error(`Name of license is incorrect. Expected "${expectedValues.name}" and got "${foundName}" `);
+      }
+
+      const foundType = document.querySelector('[data-test-license-type]').innerText;
+      if (foundType !== expectedValues.type) {
+        throw Error(`Type of license is incorrect. Expected "${expectedValues.type}" and got "${foundType}" `);
+      }
+
+      const foundStatus = document.querySelector('[data-test-license-status]').innerText;
+      if (foundStatus !== expectedValues.status) {
+        throw Error(`Status of license is incorrect. Expected "${expectedValues.status}" and got "${foundStatus}" `);
+      }
+
+      const foundDescription = document.querySelector('[data-test-license-description]').innerText;
+      if (foundDescription !== expectedValues.description) {
+        throw Error(`Description of license is incorrect. Expected "${expectedValues.description}" and got "${foundDescription}" `);
+      }
+    }, values)
+    .then(done)
+    .catch(done);
+
+  return values;
+};
+
+module.exports.generateLicenseValues = generateLicenseValues;
+module.exports.createLicense = createLicense;
+
+module.exports.test = (uiTestCtx) => {
+  describe('Module test: ui-licenses: basic license crud', function test() {
+    const { config, helpers: { login, logout } } = uiTestCtx;
+    const nightmare = new Nightmare(config.nightmare);
+    const values = generateLicenseValues();
+
+    this.timeout(Number(config.test_timeout));
+
+    describe('Login > open licenses > create, view, edit license > logout', () => {
+      before((done) => {
+        login(nightmare, config, done);
+      });
+
+      after((done) => {
+        logout(nightmare, config, done);
+      });
+
+      it('should open app and navigate to Licenses', done => {
+        nightmare
+          .wait('#clickable-licenses-module')
+          .click('#clickable-licenses-module')
+          .wait('#licenses-module-display')
+          .evaluate(() => document.location.pathname)
+          .then(pathName => {
+            if (!pathName.includes('/licenses')) throw Error('URL is incorrect');
+            done();
+          })
+          .catch(done);
+      });
+
+      it('should create license', done => {
+        createLicense(nightmare, done, values);
+      });
+
+      it(`should search for and find license: ${values.name}`, done => {
+        nightmare
+          .wait('#input-license-search')
+          .insert('#input-license-search', values.name)
+          .click('[data-test-search-and-sort-submit]')
+          .wait(1000) // If another license was open wait for the new one to be open before the next operation.
+          .wait('#licenseInfo')
+          .evaluate(expectedValues => {
+            const node = document.querySelector('[data-test-license-name]');
+            if (!node || !node.innerText) throw Error('No license name node found.');
+
+            const name = node.innerText;
+            if (name !== expectedValues.name) {
+              throw Error(`Name of found license is incorrect. Expected "${expectedValues.name}" and got "${name}" `);
+            }
+          }, values)
+          .then(done)
+          .catch(done);
+      });
+
+      it(`should edit license to: ${values.editedName}`, done => {
+        nightmare
+          .click('[class*=paneHeader] [class*=dropdown] button')
+          .wait('#clickable-edit-license')
+          .click('#clickable-edit-license')
+          .wait('#licenseFormInfo')
+          .insert('#edit-license-name', '')
+          .insert('#edit-license-name', values.editedName)
+
+          .click('#datepicker-clear-button-edit-license-start-date')
+          .insert('#edit-license-start-date', '2020-02-02')
+          .click('#datepicker-clear-button-edit-license-end-date')
+          .insert('#edit-license-end-date', '2020-02-12')
+
+          .type('#edit-license-type', values.editedType)
+          .type('#edit-license-status', values.editedStatus)
+          .click('#clickable-updatelicense')
+          .wait('#licenseInfo')
+          .wait(5000) // Wait for the POST/reloading to trigger since #licenseInfo may be up for some ms first.
+          .evaluate(expectedValues => {
+            const name = document.querySelector('[data-test-license-name]').innerText;
+            if (name !== expectedValues.editedName) {
+              throw Error(`Name of found license is incorrect. Expected "${expectedValues.editedName}" and got "${name}" `);
+            }
+
+            const type = document.querySelector('[data-test-license-type]').innerText;
+            if (type !== expectedValues.editedType) {
+              throw Error(`Type of license is incorrect. Expected "${expectedValues.editedType}" and got "${type}" `);
+            }
+
+            const status = document.querySelector('[data-test-license-status]').innerText;
+            if (status !== expectedValues.editedStatus) {
+              throw Error(`Status of license is incorrect. Expected "${expectedValues.editedStatus}" and got "${status}" `);
+            }
+          }, values)
+          .then(done)
+          .catch(done);
+      });
+
+      it('should reject endDate <= startDate', done => {
+        nightmare
+          .click('[class*=paneHeader] [class*=dropdown] button')
+          .wait('#clickable-edit-license')
+          .click('#clickable-edit-license')
+          .wait('#licenseFormInfo')
+          .insert('#edit-license-name', '')
+          .insert('#edit-license-name', values.editedName)
+
+          .click('#datepicker-clear-button-edit-license-start-date')
+          .type('#edit-license-start-date', '1968-01-05')
+          .click('#datepicker-clear-button-edit-license-end-date')
+          .type('#edit-license-end-date', '1968-01-05\u000d')
+          .wait(1000)
+
+          .evaluate(() => {
+            const error = document.querySelector('[data-test-error-end-date-too-early]');
+            if (!error) {
+              throw Error('Expected to find an error message at [data-test-error-end-date-too-early] for the End Date');
+            }
+          }, values)
+          .then(() => {
+            nightmare.click('form button[icon=times]');
+          })
+          .then(done)
+          .catch(done);
+      });
+    });
+  });
+};

--- a/test/ui-testing/crud.js
+++ b/test/ui-testing/crud.js
@@ -111,7 +111,7 @@ module.exports.test = (uiTestCtx) => {
       });
 
       it('should create license with correct default values', done => {
-        const defaults = generateLicenseValues();
+        const name = `Default License #${Math.round(Math.random() * 100000)}`;
         nightmare
           .wait('#clickable-licenses-module')
           .click('#clickable-licenses-module')
@@ -121,15 +121,15 @@ module.exports.test = (uiTestCtx) => {
 
           .waitUntilNetworkIdle(2000) // Wait for the default values to be fetched and set.
 
-          .insert('#edit-license-name', defaults.name)
+          .insert('#edit-license-name', name)
 
           .click('#clickable-createlicense')
           .wait('#licenseInfo')
-          .waitUntilNetworkIdle(500)
-          .evaluate(expectedValues => {
+          .waitUntilNetworkIdle(1000)
+          .evaluate(expectedName => {
             const foundName = document.querySelector('[data-test-license-name]').innerText;
-            if (foundName !== expectedValues.name) {
-              throw Error(`Name of license is incorrect. Expected "${expectedValues.name}" and got "${foundName}" `);
+            if (foundName !== expectedName) {
+              throw Error(`Name of license is incorrect. Expected "${expectedName}" and got "${foundName}" `);
             }
 
             const foundType = document.querySelector('[data-test-license-type]').innerText;
@@ -141,7 +141,7 @@ module.exports.test = (uiTestCtx) => {
             if (foundStatus !== 'Active') {
               throw Error(`Status of license is incorrect. Expected "Active" and got "${foundStatus}" `);
             }
-          }, defaults)
+          }, name)
           .then(() => nightmare.click('#pane-view-license button[icon=times]'))
           .then(done)
           .catch(done);
@@ -159,6 +159,7 @@ module.exports.test = (uiTestCtx) => {
           .click('[data-test-search-and-sort-submit]')
           .wait(1000) // If another license was open wait for the new one to be open before the next operation.
           .wait('#licenseInfo')
+          .waitUntilNetworkIdle(1000)
           .evaluate(expectedValues => {
             const node = document.querySelector('[data-test-license-name]');
             if (!node || !node.innerText) throw Error('No license name node found.');
@@ -190,7 +191,7 @@ module.exports.test = (uiTestCtx) => {
           .type('#edit-license-status', values.editedStatus)
           .click('#clickable-updatelicense')
           .wait('#licenseInfo')
-          .wait(5000) // Wait for the POST/reloading to trigger since #licenseInfo may be up for some ms first.
+          .waitUntilNetworkIdle(1000)
           .evaluate(expectedValues => {
             const name = document.querySelector('[data-test-license-name]').innerText;
             if (name !== expectedValues.editedName) {


### PR DESCRIPTION
Added the following tests:
```    Module test: ui-licenses: basic license crud
      Login > open licenses > create, view, edit license > logout
        ✓ should open app and navigate to Licenses (859ms)
        ✓ should clear default status filters (324ms)
        ✓ should create license with correct default values (8313ms)
        ✓ should create license (7346ms)
        ✓ should search for and find license: Fledgling License #90043 (2341ms)
        ✓ should edit license to: Edited License #90043 (5702ms)
        ✓ should reject endDate <= startDate (7813ms)
```

Tests can be run inside of `ui-licenses` via `yarn test` with the optional `--local` and `--show` arguments to run them against `localhost:3000` and display the tests in a browser, respectively.