### PR TITLE
ERM-16: Added ability to make licenses Open Ended

### DIFF
--- a/src/components/EditLicense/EditLicense.js
+++ b/src/components/EditLicense/EditLicense.js
@@ -11,10 +11,6 @@ const handleSubmit = (agreement, dispatch, props) => {
     .then(() => props.onCancel());
 };
 
-const validate = (values, props) => {
-  return props.validateLicense(values, props);
-};
-
 class EditLicense extends React.Component {
   static propTypes = {
     initialValues: PropTypes.object,
@@ -27,7 +23,6 @@ class EditLicense extends React.Component {
     submitting: PropTypes.bool,
     parentResources: PropTypes.object,
     parentMutator: PropTypes.object,
-    validateLicense: PropTypes.func.isRequired,
   }
 
   renderFirstMenu() {
@@ -98,7 +93,6 @@ class EditLicense extends React.Component {
 export default stripesForm({
   form: 'EditLicense',
   onSubmit: handleSubmit,
-  validate,
   navigationCheck: true,
   enableReinitialize: true,
   keepDirtyOnReinitialize: true,

--- a/src/components/LicenseForm/Sections/LicenseFormInfo.js
+++ b/src/components/LicenseForm/Sections/LicenseFormInfo.js
@@ -29,6 +29,10 @@ class LicenseFormInfo extends React.Component {
     }),
   };
 
+  state = {
+    openEnded: false,
+  }
+
   getStatusValues() {
     return get(this.props.parentResources.statusValues, ['records'], [])
       .map(({ id, label }) => ({ label, value: id }));
@@ -49,6 +53,37 @@ class LicenseFormInfo extends React.Component {
       parentMutator: this.props.parentMutator,
       parentResources: this.props.parentResources,
     };
+  }
+
+  warnEndDate = (endDate, allValues) => {
+    this.setState({ openEnded: allValues.openEnded });
+
+    if (allValues.openEnded && endDate) {
+      return (
+        <div data-test-warn-clear-end-date>
+          <FormattedMessage id="ui-licenses.warn.clearEndDate" />
+        </div>
+      );
+    }
+
+    return undefined;
+  }
+
+  validateEndDate = (value, allValues) => {
+    if (value && allValues.startDate) {
+      const startDate = new Date(allValues.startDate);
+      const endDate = new Date(allValues.endDate);
+
+      if (startDate >= endDate) {
+        return (
+          <div data-test-error-end-date-too-early>
+            <FormattedMessage id="ui-licenses.errors.endDateGreaterThanStartDate" />
+          </div>
+        );
+      }
+    }
+
+    return undefined;
   }
 
   render() {
@@ -118,26 +153,18 @@ class LicenseFormInfo extends React.Component {
               component={Datepicker}
               dateFormat="YYYY-MM-DD"
               backendDateStandard="YYYY-MM-DD"
+              disabled={this.state.openEnded}
+              validate={this.validateEndDate}
+              warn={this.warnEndDate}
             />
           </Col>
           <Col xs={2} style={{ paddingTop: 20 }}>
             <Field
-              id="edit-license-end-date-semantics"
-              name="endDateSemantics"
-              label={<FormattedMessage id="ui-licenses.prop.endDateSemantics" />}
+              id="edit-license-open-ended"
+              name="openEnded"
+              label={<FormattedMessage id="ui-licenses.prop.openEnded" />}
               component={Checkbox}
               type="checkbox"
-              parse={v => (v ? 'open_ended' : 'explicit')}
-              format={v => {
-                if (typeof v === 'string') return v === 'open_ended';
-
-                if (typeof v === 'object' && v.id) {
-                  const openEndedValue = this.getEndDateOpenEnded();
-                  return v.id === openEndedValue.id;
-                }
-
-                return v;
-              }}
             />
           </Col>
         </Row>

--- a/src/components/LicenseForm/Sections/LicenseFormInfo.js
+++ b/src/components/LicenseForm/Sections/LicenseFormInfo.js
@@ -7,6 +7,7 @@ import { Field } from 'redux-form';
 import {
   Accordion,
   AccordionSet,
+  Checkbox,
   Col,
   Datepicker,
   Row,
@@ -24,6 +25,7 @@ class LicenseFormInfo extends React.Component {
     parentResources: PropTypes.shape({
       statusValues: PropTypes.object,
       typeValues: PropTypes.object,
+      endDateSemanticsValues: PropTypes.object,
     }),
   };
 
@@ -35,6 +37,11 @@ class LicenseFormInfo extends React.Component {
   getTypeValues() {
     return get(this.props.parentResources.typeValues, ['records'], [])
       .map(({ id, label }) => ({ label, value: id }));
+  }
+
+  getEndDateOpenEnded() {
+    return get(this.props.parentResources.endDateSemanticsValues, ['records'], [])
+      .find(v => v.value === 'open_ended') || {};
   }
 
   getSectionProps() {
@@ -71,7 +78,7 @@ class LicenseFormInfo extends React.Component {
           </Col>
         </Row>
         <Row>
-          <Col xs={12} md={3}>
+          <Col xs={12} md={6}>
             <Field
               id="edit-license-type"
               component={Select}
@@ -81,7 +88,7 @@ class LicenseFormInfo extends React.Component {
               required
             />
           </Col>
-          <Col xs={12} md={3}>
+          <Col xs={12} md={6}>
             <Field
               id="edit-license-status"
               component={Select}
@@ -91,7 +98,9 @@ class LicenseFormInfo extends React.Component {
               required
             />
           </Col>
-          <Col xs={12} md={3}>
+        </Row>
+        <Row>
+          <Col xs={12} md={5}>
             <Field
               id="edit-license-start-date"
               name="startDate"
@@ -101,7 +110,7 @@ class LicenseFormInfo extends React.Component {
               backendDateStandard="YYYY-MM-DD"
             />
           </Col>
-          <Col xs={12} md={3}>
+          <Col xs={10} md={5}>
             <Field
               id="edit-license-end-date"
               name="endDate"
@@ -109,6 +118,26 @@ class LicenseFormInfo extends React.Component {
               component={Datepicker}
               dateFormat="YYYY-MM-DD"
               backendDateStandard="YYYY-MM-DD"
+            />
+          </Col>
+          <Col xs={2} style={{ paddingTop: 20 }}>
+            <Field
+              id="edit-license-end-date-semantics"
+              name="endDateSemantics"
+              label={<FormattedMessage id="ui-licenses.prop.endDateSemantics" />}
+              component={Checkbox}
+              type="checkbox"
+              parse={v => (v ? 'open_ended' : 'explicit')}
+              format={v => {
+                if (typeof v === 'string') return v === 'open_ended';
+
+                if (typeof v === 'object' && v.id) {
+                  const openEndedValue = this.getEndDateOpenEnded();
+                  return v.id === openEndedValue.id;
+                }
+
+                return v;
+              }}
             />
           </Col>
         </Row>

--- a/src/components/ViewLicense/Sections/LicenseInfo.js
+++ b/src/components/ViewLicense/Sections/LicenseInfo.js
@@ -21,6 +21,12 @@ class LicenseInfo extends React.Component {
     this.props.license.parent = { id : license.id, name: license.name };
   }
 
+  renderEndDate(license) {
+    if (license.openEnded) return <FormattedMessage id="ui-licenses.prop.openEnded" />;
+    if (license.endDate) return <FormattedDate value={license.endDate} />;
+
+    return '-';
+  }
 
   render() {
     const { license } = this.props;
@@ -66,7 +72,7 @@ class LicenseInfo extends React.Component {
           <Col xs={6} md={3}>
             <KeyValue label={<FormattedMessage id="ui-licenses.prop.endDate" />}>
               <div data-test-license-end-date>
-                {license.endDate ? <FormattedDate value={license.endDate} /> : '-'}
+                {this.renderEndDate(license)}
               </div>
             </KeyValue>
           </Col>

--- a/src/routes/Licenses.js
+++ b/src/routes/Licenses.js
@@ -44,6 +44,10 @@ export default class Licenses extends React.Component {
       type: 'okapi',
       path: 'licenses/refdata/License/type',
     },
+    endDateSemanticsValues: {
+      type: 'okapi',
+      path: 'licenses/refdata/License/endDateSemantics',
+    },
     query: { initialValue: {} },
     resultCount: { initialValue: INITIAL_RESULT_COUNT },
     selectedLicenseId: { initialValue: '' },

--- a/src/routes/Licenses.js
+++ b/src/routes/Licenses.js
@@ -44,10 +44,6 @@ export default class Licenses extends React.Component {
       type: 'okapi',
       path: 'licenses/refdata/License/type',
     },
-    endDateSemanticsValues: {
-      type: 'okapi',
-      path: 'licenses/refdata/License/endDateSemantics',
-    },
     query: { initialValue: {} },
     resultCount: { initialValue: INITIAL_RESULT_COUNT },
     selectedLicenseId: { initialValue: '' },
@@ -109,25 +105,6 @@ export default class Licenses extends React.Component {
     return this.props.mutator.selectedLicense.PUT(license);
   }
 
-  validateLicense = (values) => {
-    const errors = {};
-
-    if (values.startDate && values.endDate) {
-      const startDate = new Date(values.startDate);
-      const endDate = new Date(values.endDate);
-
-      if (startDate >= endDate) {
-        errors.endDate = (
-          <div data-test-error-end-date-too-early>
-            <FormattedMessage id="ui-licenses.errors.endDateGreaterThanStartDate" />
-          </div>
-        );
-      }
-    }
-
-    return errors;
-  }
-
   getActiveFilters = () => {
     const { query } = this.props.resources;
 
@@ -181,7 +158,6 @@ export default class Licenses extends React.Component {
         }}
         detailProps={{
           onUpdate: this.handleUpdate,
-          validateLicense: this.validateLicense,
         }}
         editRecordComponent={EditLicense}
         initialResultCount={INITIAL_RESULT_COUNT}

--- a/translations/ui-licenses/en.json
+++ b/translations/ui-licenses/en.json
@@ -11,8 +11,8 @@
 
   "prop.description": "Description",
   "prop.endDate": "End date",
-  "prop.endDateSemantics": "Open ended",
   "prop.name": "Name",
+  "prop.openEnded": "Open ended",
   "prop.parentLicense": "Parent License",
   "prop.terms": "License Terms",
   "prop.startDate": "Start date",
@@ -25,6 +25,8 @@
   "section.licenseInformation": "License information",
   "section.organizations": "Organizations",
   "section.terms": "Terms",
+
+  "warn.clearEndDate": "This value will be cleared when saving because \"Open ended\" is checked.",
 
   "settings.general": "General",
   "settings.general.message": "These are your general app settings.",

--- a/translations/ui-licenses/en.json
+++ b/translations/ui-licenses/en.json
@@ -11,6 +11,7 @@
 
   "prop.description": "Description",
   "prop.endDate": "End date",
+  "prop.endDateSemantics": "Open ended",
   "prop.name": "Name",
   "prop.parentLicense": "Parent License",
   "prop.terms": "License Terms",


### PR DESCRIPTION
- Create/Edit: New "Open ended" checkbox to control the `openEnded` field.
  - End date will show a warning when it and the checkbox have a value since the end date will be overridden by the backend.
- View: **End date** is displayed as "Open ended" when the `openEnded` field is `true`.