### PR TITLE
Formatted dates in search results

### DIFF
--- a/src/routes/Licenses.js
+++ b/src/routes/Licenses.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
+import { FormattedDate, FormattedMessage } from 'react-intl';
 import { get } from 'lodash';
 
 import { SearchAndSort } from '@folio/stripes/smart-components';
@@ -147,6 +147,13 @@ export default class Licenses extends React.Component {
     );
   }
 
+  renderEndDate = (license) => {
+    if (license.openEnded) return <FormattedMessage id="ui-licenses.prop.openEnded" />;
+    if (license.endDate) return <FormattedDate value={license.endDate} />;
+
+    return '';
+  }
+
   render() {
     return (
       <SearchAndSort
@@ -184,7 +191,9 @@ export default class Licenses extends React.Component {
         resultCountIncrement={INITIAL_RESULT_COUNT}
         resultsFormatter={{
           type: a => a.type && a.type.label,
-          status: a => a.status && a.status.label
+          status: a => a.status && a.status.label,
+          startDate: a => (a.startDate ? <FormattedDate value={a.startDate} /> : ''),
+          endDate: this.renderEndDate,
         }}
         showSingleResult
         viewRecordComponent={ViewLicense}


### PR DESCRIPTION
- Used `FormattedDate` to format the dates according to the current locale.
- Show "Open ended" as the end date when the license has been marked as open-ended.