### PR TITLE
ERM-56: Always show primary terms when editing license

### DIFF
--- a/src/components/ViewLicense/ViewLicense.js
+++ b/src/components/ViewLicense/ViewLicense.js
@@ -30,6 +30,9 @@ class ViewLicense extends React.Component {
   });
 
   static propTypes = {
+    defaultLicenseValues: PropTypes.shape({
+      customProperties: PropTypes.object,
+    }),
     editLink: PropTypes.string,
     match: PropTypes.object,
     mutator: PropTypes.shape({
@@ -61,7 +64,7 @@ class ViewLicense extends React.Component {
 
   getInitialValues = () => {
     const license = cloneDeep(this.getLicense());
-    const { orgs, status, type } = license;
+    const { customProperties = {}, orgs, status, type } = license;
 
     if (status && status.id) {
       license.status = status.id;
@@ -74,6 +77,12 @@ class ViewLicense extends React.Component {
     if (orgs && orgs.length) {
       license.orgs = orgs.map(o => ({ ...o, role: o.role.id }));
     }
+
+    const defaultCustomProperties = get(this.props.defaultLicenseValues, ['customProperties'], {});
+    license.customProperties = {
+      ...defaultCustomProperties,
+      ...customProperties,
+    };
 
     return license;
   }

--- a/src/routes/Licenses.js
+++ b/src/routes/Licenses.js
@@ -189,6 +189,7 @@ export default class Licenses extends React.Component {
         }}
         detailProps={{
           onUpdate: this.handleUpdate,
+          defaultLicenseValues: this.getDefaultLicenseValues(),
         }}
         editRecordComponent={EditLicense}
         initialResultCount={INITIAL_RESULT_COUNT}

--- a/test/ui-testing/term.js
+++ b/test/ui-testing/term.js
@@ -122,31 +122,31 @@ module.exports.test = (uiTestCtx, term = TERM) => {
           .click('#clickable-edit-license')
           .wait('#licenseFormInfo')
           .waitUntilNetworkIdle(2000)
-          .evaluate((expectedTerm) => {
-            const nameElement = document.querySelector('#edit-term-0-name');
-            const valueElement = document.querySelector('#edit-term-0-value');
+          .evaluate((expectedTerm, row) => {
+            const nameElement = document.querySelector(`#edit-term-${row}-name`);
+            const valueElement = document.querySelector(`#edit-term-${row}-value`);
 
             if (nameElement.selectedOptions[0].textContent !== expectedTerm.label) {
-              throw Error(`Expected #edit-term-0-name to have label ${expectedTerm.label}`);
+              throw Error(`Expected #edit-term-${row}-name to have label ${expectedTerm.label}`);
             }
             if (nameElement.value !== expectedTerm.name) {
-              throw Error(`Expected #edit-term-0-name to have value ${expectedTerm.name}`);
+              throw Error(`Expected #edit-term-${row}-name to have value ${expectedTerm.name}`);
             }
             const value = valueElement.selectedOptions ?
               valueElement.selectedOptions[0].textContent : valueElement.value;
 
             if (value !== expectedTerm.value) {
-              throw Error(`Expected #edit-term-0-value to be ${expectedTerm.value}. It is ${value}`);
+              throw Error(`Expected #edit-term-${row}-value to be ${expectedTerm.value}. It is ${value}`);
             }
-          }, term)
+          }, term, NUMBER_OF_TERMS - 1)
           .then(done)
           .catch(done);
       });
 
       it(`should edit term value to: ${term.editedValue}`, done => {
         nightmare
-          .insert('#edit-term-0-value', '')
-          .type('#edit-term-0-value', term.editedValue)
+          .insert(`#edit-term-${NUMBER_OF_TERMS - 1}-value`, '')
+          .type(`#edit-term-${NUMBER_OF_TERMS - 1}-value`, term.editedValue)
           .then(done)
           .catch(done);
       });
@@ -192,31 +192,31 @@ module.exports.test = (uiTestCtx, term = TERM) => {
           .click('#clickable-edit-license')
           .wait('#licenseFormInfo')
           .waitUntilNetworkIdle(2000)
-          .evaluate((expectedTerm) => {
-            const nameElement = document.querySelector('#edit-term-0-name');
-            const valueElement = document.querySelector('#edit-term-0-value');
+          .evaluate((expectedTerm, row) => {
+            const nameElement = document.querySelector(`#edit-term-${row}-name`);
+            const valueElement = document.querySelector(`#edit-term-${row}-value`);
 
             if (expectedTerm.label !== nameElement.selectedOptions[0].textContent) {
-              throw Error(`Expected #edit-term-0-name to have label ${expectedTerm.label}`);
+              throw Error(`Expected #edit-term-${row}-name to have label ${expectedTerm.label}`);
             }
             if (expectedTerm.name !== nameElement.value) {
-              throw Error(`Expected #edit-term-0-name to have label ${expectedTerm.name}`);
+              throw Error(`Expected #edit-term-${row}-name to have label ${expectedTerm.name}`);
             }
 
             const value = valueElement.selectedOptions ?
               valueElement.selectedOptions[0].textContent : valueElement.value;
 
             if (value !== expectedTerm.editedValue) {
-              throw Error(`Expected #edit-term-0-value to be ${expectedTerm.editedValue}. It is ${value}`);
+              throw Error(`Expected #edit-term-${row}-value to be ${expectedTerm.editedValue}. It is ${value}`);
             }
-          }, term)
+          }, term, NUMBER_OF_TERMS - 1)
           .then(done)
           .catch(done);
       });
 
       it('should remove term from license and save', done => {
         nightmare
-          .click('#edit-term-0-delete')
+          .click(`#edit-term-${NUMBER_OF_TERMS - 1}-delete`)
           .wait(500)
           .click('#clickable-updatelicense')
           .waitUntilNetworkIdle(2000) // Wait for record to be fetched


### PR DESCRIPTION
**Before**: When editing a license, only the previously-set terms were displayed on load. This is because I read ERM-6 incorrectly.

**After**: When editing a license, the previously-set terms are displayed along with the primary terms. They are displayed in their weighted order.
