### PR TITLE
Tweaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2.2.0
 * Added name export of Licenses search UI
+* Use `LicenseCard` when rendering license header.
 
 ## 2.1.0
 * Added ability to view, add, edit, and remove core documents from licenses.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/licenses",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "description": "ERM License functionality for Stripes",
   "main": "src/index.js",
   "repository": "",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "eslint": "^5.5.0"
   },
   "dependencies": {
-    "@folio/stripes-erm-components": "^1.0.5",
+    "@folio/stripes-erm-components": "^1.0.6",
     "lodash": "^4.17.4",
     "prop-types": "^15.6.0",
     "react-intl": "^2.4.0",

--- a/src/components/ViewLicense/sections/LicenseCoreDocs.js
+++ b/src/components/ViewLicense/sections/LicenseCoreDocs.js
@@ -11,6 +11,7 @@ import { DocumentCard, Spinner } from '@folio/stripes-erm-components';
 
 export default class LicenseCoreDocs extends React.Component {
   static propTypes = {
+    id: PropTypes.string,
     license: PropTypes.shape({
       docs: PropTypes.arrayOf(
         PropTypes.shape({
@@ -23,6 +24,8 @@ export default class LicenseCoreDocs extends React.Component {
         }),
       ),
     }).isRequired,
+    onToggle: PropTypes.func,
+    open: PropTypes.bool,
   };
 
   renderDocs = (docs) => {
@@ -35,14 +38,17 @@ export default class LicenseCoreDocs extends React.Component {
   }
 
   render() {
+    const { id, onToggle, open } = this.props;
     const { docs = [] } = this.props.license;
 
     return (
       <Accordion
         displayWhenClosed={this.renderBadge()}
         displayWhenOpen={this.renderBadge()}
-        id="license-docs"
+        id={id}
         label={<FormattedMessage id="ui-licenses.section.coreDocs" />}
+        onToggle={onToggle}
+        open={open}
       >
         <Layout className="padding-bottom-gutter">
           { docs.length ? this.renderDocs(docs) : <FormattedMessage id="ui-licenses.coreDocs.none" /> }

--- a/src/components/ViewLicense/sections/LicenseHeader.js
+++ b/src/components/ViewLicense/sections/LicenseHeader.js
@@ -1,91 +1,25 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { get } from 'lodash';
-import { FormattedDate, FormattedMessage } from 'react-intl';
-
-import {
-  Col,
-  KeyValue,
-  Row,
-} from '@folio/stripes/components';
+import { LicenseCard } from '@folio/stripes-erm-components';
 
 import css from './LicenseHeader.css';
 
 export default class LicenseHeader extends React.Component {
   static propTypes = {
-    license: PropTypes.shape({
-      orgs: PropTypes.arrayOf(
-        PropTypes.shape({
-          org: PropTypes.shape({
-            name: PropTypes.string,
-          }),
-          role: PropTypes.shape({
-            value: PropTypes.string,
-          }),
-        }),
-      ),
-    }),
+    license: PropTypes.object,
   }
 
   static defaultProps = {
     license: {},
   }
 
-  renderLicensor = () => {
-    const { license: { orgs = [] } } = this.props;
-    const licensor = orgs.find(o => get(o, ['role', 'value']) === 'licensor');
-    const licensorName = get(licensor, ['org', 'name']) || <FormattedMessage id="ui-licenses.notSet" />;
-
-    return licensorName;
-  }
-
-  renderEndDate() {
-    const { license } = this.props;
-    if (license.openEnded) return <FormattedMessage id="ui-licenses.prop.openEnded" />;
-    if (license.endDate) return <FormattedDate value={license.endDate} />;
-
-    return '-';
-  }
-
   render() {
-    const { license } = this.props;
-
     return (
-      <Row className={css.licenseHeader}>
-        <Col xs={2}>
-          <KeyValue label={<FormattedMessage id="ui-licenses.prop.type" />}>
-            <div data-test-header-type>
-              {get(license, ['type', 'label'], '-')}
-            </div>
-          </KeyValue>
-        </Col>
-        <Col xs={2}>
-          <KeyValue label={<FormattedMessage id="ui-licenses.prop.status" />}>
-            <div data-test-header-status>
-              {get(license, ['status', 'label'], '-')}
-            </div>
-          </KeyValue>
-        </Col>
-        <Col xs={2}>
-          <KeyValue label={<FormattedMessage id="ui-licenses.prop.startDate" />}>
-            <div data-test-header-start-date>
-              {license.startDate ? <FormattedDate value={license.startDate} /> : '-'}
-            </div>
-          </KeyValue>
-        </Col>
-        <Col xs={3}>
-          <KeyValue label={<FormattedMessage id="ui-licenses.prop.endDate" />}>
-            <div data-test-header-end-date>
-              {this.renderEndDate()}
-            </div>
-          </KeyValue>
-        </Col>
-        <Col xs={3}>
-          <KeyValue label={<FormattedMessage id="ui-licenses.header.licensor" />}>
-            <div data-test-header-licensor-name>{this.renderLicensor()}</div>
-          </KeyValue>
-        </Col>
-      </Row>
+      <LicenseCard
+        className={css.licenseHeader}
+        license={this.props.license}
+        renderName={false}
+      />
     );
   }
 }

--- a/src/components/ViewLicense/sections/LicenseOrganizations.js
+++ b/src/components/ViewLicense/sections/LicenseOrganizations.js
@@ -59,6 +59,7 @@ export default class LicenseOrganizations extends React.Component {
   render() {
     return (
       <Accordion
+        closedByDefault
         displayWhenClosed={this.renderBadge()}
         displayWhenOpen={this.renderBadge()}
         id="license-orgs"

--- a/test/ui-testing/orgs.js
+++ b/test/ui-testing/orgs.js
@@ -150,7 +150,7 @@ module.exports.test = (uiTestCtx) => {
         it(`should find ${licensor.name} in header as Licensor`, done => {
           nightmare
             .evaluate(o => {
-              const headerLicensor = document.querySelector('[data-test-header-licensor-name]').textContent;
+              const headerLicensor = document.querySelector('[data-test-license-card-licensor-name]').textContent;
               if (headerLicensor !== o.name) {
                 throw Error(`Expected to find Licensor as ${o.name}. It is ${headerLicensor}.`);
               }


### PR DESCRIPTION
- Core Docs: Use passed-in accordion props
- Organizations: Set `closedByDefault` (not functional currently due to STCOM-480)
- License Header: Use generic `LicenseCard` component from folio-org/stripes-erm-components#18