### PR TITLE
ERM-125: Fixed default sort order for Linked Agreements

### DIFF
--- a/src/components/ViewLicense/ViewLicense.js
+++ b/src/components/ViewLicense/ViewLicense.js
@@ -32,7 +32,7 @@ class ViewLicense extends React.Component {
       type: 'okapi',
       path: 'licenses/licenses/:{id}/linkedAgreements',
       params: {
-        sort: 'owner.startDate;asc'
+        sort: 'owner.startDate;desc'
       },
       throwErrors: false,
     },


### PR DESCRIPTION
Most recent agreement should be first, not last.