### PR TITLE
Fixed front-end licensor validation

### DIFF
--- a/src/components/LicenseForm/components/OrganizationsFieldArray.js
+++ b/src/components/LicenseForm/components/OrganizationsFieldArray.js
@@ -33,25 +33,9 @@ class OrganizationsFieldArray extends React.Component {
     roles: [],
   }
 
-  state = {
-    licensorRoleId: undefined,
-  }
-
-  static getDerivedStateFromProps(nextProps, state) {
-    const { roles } = nextProps;
-    if (!state.licensorRoleId && roles.length) {
-      return {
-        licensorRoleId: (roles.find(r => r.value === 'licensor') || {}).id,
-      };
-    }
-
-    return null;
-  }
-
   validateMultipleLicensors = (value, allValues) => {
-    const { licensorRoleId } = this.state;
-    if (value === licensorRoleId) {
-      const licensorOrgs = allValues.orgs.filter(o => o.role === licensorRoleId);
+    if (value === 'licensor') {
+      const licensorOrgs = allValues.orgs.filter(o => o.role === 'licensor');
       if (licensorOrgs.length > 1) {
         return <FormattedMessage id="ui-licenses.errors.multipleLicensors" />;
       }


### PR DESCRIPTION
We save values now instead of IDs, so no need to maintain the look-up of IDs anymore and we can key off the `licensor` value directly.