### PR TITLE
ERM-257: Added ability to attach files to core/supplementary docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change history for ui-licenses
 
-## 2.3.0 (IN PROGRESS)
+## 3.2.0
+* Added ability to attach files to documents.
+
+## 2.3.0
 * Added ability to view agreements linked to a license.
 
 ## 2.2.0

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "eslint": "^5.5.0"
   },
   "dependencies": {
-    "@folio/stripes-erm-components": "^1.3.2",
+    "@folio/stripes-erm-components": "^1.3.6",
     "lodash": "^4.17.11",
     "prop-types": "^15.6.0",
     "react-intl": "^2.4.0",

--- a/src/components/License/License.js
+++ b/src/components/License/License.js
@@ -44,13 +44,14 @@ class License extends React.Component {
   }
 
   getSectionProps = (id) => {
-    const { data } = this.props;
+    const { data, handlers } = this.props;
 
     return {
       id,
+      handlers,
+      license: data.license,
       onToggle: this.handleSectionToggle,
       open: this.state.sections[id],
-      license: data.license,
       terms: data.terms,
       users: data.users,
     };

--- a/src/components/License/sections/LicenseCoreDocs.js
+++ b/src/components/License/sections/LicenseCoreDocs.js
@@ -12,6 +12,9 @@ import { DocumentCard, Spinner } from '@folio/stripes-erm-components';
 export default class LicenseCoreDocs extends React.Component {
   static propTypes = {
     id: PropTypes.string,
+    handlers: PropTypes.shape({
+      onDownloadFile: PropTypes.func,
+    }),
     license: PropTypes.shape({
       docs: PropTypes.arrayOf(
         PropTypes.shape({
@@ -29,7 +32,13 @@ export default class LicenseCoreDocs extends React.Component {
   };
 
   renderDocs = (docs) => {
-    return docs.map(doc => <DocumentCard key={doc.id} {...doc} />);
+    return docs.map(doc => (
+      <DocumentCard
+        key={doc.id}
+        onDownloadFile={this.props.handlers.onDownloadFile}
+        {...doc}
+      />
+    ));
   }
 
   renderBadge = () => {

--- a/src/components/License/sections/LicenseSupplement.js
+++ b/src/components/License/sections/LicenseSupplement.js
@@ -12,6 +12,9 @@ import { DocumentCard, Spinner } from '@folio/stripes-erm-components';
 export default class LicenseSupplement extends React.Component {
   static propTypes = {
     id: PropTypes.string,
+    handlers: PropTypes.shape({
+      onDownloadFile: PropTypes.func,
+    }),
     license: PropTypes.shape({
       supplementaryDocs: PropTypes.arrayOf(
         PropTypes.shape({
@@ -29,8 +32,14 @@ export default class LicenseSupplement extends React.Component {
   };
 
 
-  renderDocs = (supplementaryDocs) => {
-    return supplementaryDocs.map(doc => <DocumentCard key={doc.id} {...doc} />);
+  renderDocs = (docs) => {
+    return docs.map(doc => (
+      <DocumentCard
+        key={doc.id}
+        onDownloadFile={this.props.handlers.onDownloadFile}
+        {...doc}
+      />
+    ));
   }
 
   renderBadge = () => {

--- a/src/components/LicenseForm/LicenseForm.js
+++ b/src/components/LicenseForm/LicenseForm.js
@@ -31,6 +31,7 @@ import css from './LicenseForm.css';
 class LicenseForm extends React.Component {
   static propTypes = {
     data: PropTypes.object,
+    handlers: PropTypes.object,
     initialValues: PropTypes.object,
     handleSubmit: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
@@ -53,10 +54,11 @@ class LicenseForm extends React.Component {
   }
 
   getSectionProps(id) {
-    const { data } = this.props;
+    const { data, handlers } = this.props;
 
     return {
       data,
+      handlers,
       id,
       onToggle: this.handleSectionToggle,
       open: this.state.sections[id],

--- a/src/components/LicenseForm/sections/LicenseFormCoreDocs.js
+++ b/src/components/LicenseForm/sections/LicenseFormCoreDocs.js
@@ -11,6 +11,7 @@ class LicenseFormCoreDocs extends React.Component {
   static propTypes = {
     handlers: PropTypes.shape({
       onDeleteFile: PropTypes.func.isRequired,
+      onDownloadFile: PropTypes.func.isRequired,
       onUploadFile: PropTypes.func.isRequired,
     }),
     id: PropTypes.string,

--- a/src/components/LicenseForm/sections/LicenseFormCoreDocs.js
+++ b/src/components/LicenseForm/sections/LicenseFormCoreDocs.js
@@ -9,13 +9,21 @@ import { DocumentsFieldArray } from '@folio/stripes-erm-components';
 
 class LicenseFormCoreDocs extends React.Component {
   static propTypes = {
+    handlers: PropTypes.shape({
+      onDeleteFile: PropTypes.func.isRequired,
+      onUploadFile: PropTypes.func.isRequired,
+    }),
     id: PropTypes.string,
     onToggle: PropTypes.func,
     open: PropTypes.bool,
   };
 
+  getDeleteFilePath = (file) => `/licenses/files/${file.id}`
+
+  getUploadFilePath = () => '/licenses/files'
+
   render() {
-    const { id, onToggle, open } = this.props;
+    const { handlers, id, onToggle, open } = this.props;
 
     return (
       <Accordion
@@ -27,6 +35,9 @@ class LicenseFormCoreDocs extends React.Component {
         <FieldArray
           addDocBtnLabel={<FormattedMessage id="ui-licenses.coreDocs.add" />}
           component={DocumentsFieldArray}
+          onDeleteFile={handlers.onDeleteFile}
+          onDownloadFile={handlers.onDownloadFile}
+          onUploadFile={handlers.onUploadFile}
           isEmptyMessage={<FormattedMessage id="ui-licenses.coreDocs.none" />}
           name="docs"
         />

--- a/src/components/LicenseForm/sections/LicenseFormSupplement.js
+++ b/src/components/LicenseForm/sections/LicenseFormSupplement.js
@@ -11,13 +11,18 @@ class LicenseFormSupplement extends React.Component {
       data: PropTypes.shape({
         documentCategories: PropTypes.array,
       }).isRequired,
+      handlers: PropTypes.shape({
+        onDeleteFile: PropTypes.func.isRequired,
+        onDownloadFile: PropTypes.func.isRequired,
+        onUploadFile: PropTypes.func.isRequired,
+      }).isRequired,
       id: PropTypes.string,
       onToggle: PropTypes.func,
       open: PropTypes.bool,
     };
 
     render() {
-      const { data, id, onToggle, open } = this.props;
+      const { data, handlers, id, onToggle, open } = this.props;
 
       return (
         <Accordion
@@ -29,9 +34,12 @@ class LicenseFormSupplement extends React.Component {
           <FieldArray
             addDocBtnLabel={<FormattedMessage id="ui-licenses.supplementaryDocs.add" />}
             component={DocumentsFieldArray}
+            documentCategories={data.documentCategories}
             isEmptyMessage={<FormattedMessage id="ui-licenses.supplementaryDocs.none" />}
             name="supplementaryDocs"
-            documentCategories={data.documentCategories}
+            onDeleteFile={handlers.onDeleteFile}
+            onDownloadFile={handlers.onDownloadFile}
+            onUploadFile={handlers.onUploadFile}
           />
         </Accordion>
       );

--- a/src/routes/CreateLicenseRoute.js
+++ b/src/routes/CreateLicenseRoute.js
@@ -7,6 +7,12 @@ import { stripesConnect } from '@folio/stripes/core';
 import View from '../components/LicenseForm';
 import NoPermissions from '../components/NoPermissions';
 
+import {
+  handleDeleteFile,
+  handleDownloadFile,
+  handleUploadFile,
+} from './handlers/file';
+
 class CreateLicenseRoute extends React.Component {
   static manifest = Object.freeze({
     licenses: {
@@ -68,6 +74,7 @@ class CreateLicenseRoute extends React.Component {
     }).isRequired,
     stripes: PropTypes.shape({
       hasPerm: PropTypes.func.isRequired,
+      okapi: PropTypes.object.isRequired,
     }).isRequired,
   };
 
@@ -112,6 +119,18 @@ class CreateLicenseRoute extends React.Component {
       });
   }
 
+  handleDeleteFile = (file) => {
+    return handleDeleteFile(file, this.props.stripes.okapi);
+  }
+
+  handleDownloadFile = (file) => {
+    handleDownloadFile(file, this.props.stripes.okapi);
+  }
+
+  handleUploadFile = (file) => {
+    return handleUploadFile(file, this.props.stripes.okapi);
+  }
+
   fetchIsPending = () => {
     return Object.values(this.props.resources)
       .filter(r => r && r.resource !== 'licenses')
@@ -133,6 +152,11 @@ class CreateLicenseRoute extends React.Component {
           terms: get(resources, 'terms.records', []),
           typeValues: get(resources, 'typeValues.records', []),
           users: get(resources, 'users.records', []),
+        }}
+        handlers={{
+          onDeleteFile: this.handleDeleteFile,
+          onDownloadFile: this.handleDownloadFile,
+          onUploadFile: this.handleUploadFile,
         }}
         initialValues={this.getInitialValues()}
         isLoading={this.fetchIsPending()}

--- a/src/routes/EditLicenseRoute.js
+++ b/src/routes/EditLicenseRoute.js
@@ -7,6 +7,12 @@ import { stripesConnect } from '@folio/stripes/core';
 import Form from '../components/LicenseForm';
 import NoPermissions from '../components/NoPermissions';
 
+import {
+  handleDeleteFile,
+  handleDownloadFile,
+  handleUploadFile,
+} from './handlers/file';
+
 class EditLicenseRoute extends React.Component {
   static manifest = Object.freeze({
     license: {
@@ -79,6 +85,7 @@ class EditLicenseRoute extends React.Component {
     }).isRequired,
     stripes: PropTypes.shape({
       hasPerm: PropTypes.func.isRequired,
+      okapi: PropTypes.object.isRequired,
     }).isRequired,
   };
 
@@ -142,7 +149,6 @@ class EditLicenseRoute extends React.Component {
     return initialValues;
   }
 
-
   handleClose = () => {
     const { location, match } = this.props;
     this.props.history.push(`/licenses/${match.params.id}${location.search}`);
@@ -152,6 +158,18 @@ class EditLicenseRoute extends React.Component {
     this.props.mutator.license
       .PUT(license)
       .then(this.handleClose);
+  }
+
+  handleDeleteFile = (file) => {
+    return handleDeleteFile(file, this.props.stripes.okapi);
+  }
+
+  handleDownloadFile = (file) => {
+    handleDownloadFile(file, this.props.stripes.okapi);
+  }
+
+  handleUploadFile = (file) => {
+    return handleUploadFile(file, this.props.stripes.okapi);
   }
 
   fetchIsPending = () => {
@@ -175,6 +193,11 @@ class EditLicenseRoute extends React.Component {
           terms: get(resources, 'terms.records', []),
           typeValues: get(resources, 'typeValues.records', []),
           users: get(resources, 'users.records', []),
+        }}
+        handlers={{
+          onDeleteFile: this.handleDeleteFile,
+          onDownloadFile: this.handleDownloadFile,
+          onUploadFile: this.handleUploadFile,
         }}
         initialValues={this.getInitialValues()}
         isLoading={this.fetchIsPending()}

--- a/src/routes/ViewLicenseRoute.js
+++ b/src/routes/ViewLicenseRoute.js
@@ -6,6 +6,8 @@ import { stripesConnect } from '@folio/stripes/core';
 
 import View from '../components/License';
 
+import { handleDownloadFile } from './handlers/file';
+
 class ViewLicenseRoute extends React.Component {
   static manifest = Object.freeze({
     license: {
@@ -56,6 +58,7 @@ class ViewLicenseRoute extends React.Component {
     }).isRequired,
     stripes: PropTypes.shape({
       hasPerm: PropTypes.func.isRequired,
+      okapi: PropTypes.object.isRequired,
     }).isRequired,
   };
 
@@ -91,6 +94,10 @@ class ViewLicenseRoute extends React.Component {
     }));
   }
 
+  handleDownloadFile = (file) => {
+    handleDownloadFile(file, this.props.stripes.okapi);
+  }
+
   handleClose = () => {
     this.props.history.push(`/licenses${this.props.location.search}`);
   }
@@ -117,6 +124,9 @@ class ViewLicenseRoute extends React.Component {
           terms: get(resources, 'terms.records', []),
         }}
         editUrl={stripes.hasPerm('ui-licenses.licenses.edit') && `${location.pathname}/edit${location.search}`}
+        handlers={{
+          onDownloadFile: this.handleDownloadFile,
+        }}
         isLoading={get(resources, 'license.isPending')}
         onClose={this.handleClose}
         onToggleHelper={this.handleTogglerHelper}

--- a/src/routes/handlers/file.js
+++ b/src/routes/handlers/file.js
@@ -1,0 +1,41 @@
+export const handleUploadFile = (file, okapi) => {
+  const formData = new FormData();
+  formData.append('upload', file);
+
+  return fetch(`${okapi.url}/licenses/files`, {
+    method: 'POST',
+    headers: {
+      'X-Okapi-Tenant': okapi.tenant,
+      'X-Okapi-Token': okapi.token,
+    },
+    body: formData,
+  }).then(response => response.json());
+};
+
+export const handleDeleteFile = (file, okapi) => {
+  return fetch(`${okapi.url}/licenses/files/${file.id}`, {
+    method: 'DELETE',
+    headers: {
+      'X-Okapi-Tenant': okapi.tenant,
+      'X-Okapi-Token': okapi.token,
+    },
+  });
+};
+
+export const handleDownloadFile = (file, okapi) => {
+  return fetch(`${okapi.url}/licenses/files/${file.id}/raw`, {
+    headers: {
+      'X-Okapi-Tenant': okapi.tenant,
+      'X-Okapi-Token': okapi.token,
+    },
+  }).then(response => response.blob())
+    .then(blob => {
+      const url = window.URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = file.name;
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+    });
+};


### PR DESCRIPTION
Uses the various changes in `DocumentsFieldArray` and `DocumentCard` added in https://github.com/folio-org/stripes-erm-components/pull/65

upload, download, delete is handled by using a new `handlers` directory in the routes. This allows code reuse when we can't just one-line handlers for reasons such as not being able to use stripes-connect (like this case).