### PR TITLE
ERM-262: Use full ISO datetime

### DIFF
--- a/src/components/formSections/AmendmentFormInfo.js
+++ b/src/components/formSections/AmendmentFormInfo.js
@@ -103,7 +103,6 @@ class AmendmentFormInfo extends React.Component {
               label={<FormattedMessage id="ui-licenses.prop.startDate" />}
               component={Datepicker}
               dateFormat="YYYY-MM-DD"
-              backendDateStandard="YYYY-MM-DD"
             />
           </Col>
           <Col xs={10} md={5}>
@@ -113,7 +112,6 @@ class AmendmentFormInfo extends React.Component {
               label={<FormattedMessage id="ui-licenses.prop.endDate" />}
               component={Datepicker}
               dateFormat="YYYY-MM-DD"
-              backendDateStandard="YYYY-MM-DD"
               disabled={this.state.openEnded}
               validate={this.validateEndDate}
               warn={this.warnEndDate}

--- a/src/components/formSections/LicenseFormInfo.js
+++ b/src/components/formSections/LicenseFormInfo.js
@@ -124,7 +124,6 @@ class LicenseFormInfo extends React.Component {
                 label={<FormattedMessage id="ui-licenses.prop.startDate" />}
                 component={Datepicker}
                 dateFormat="YYYY-MM-DD"
-                backendDateStandard="YYYY-MM-DD"
               />
             </Col>
             <Col xs={10} md={5}>
@@ -134,7 +133,6 @@ class LicenseFormInfo extends React.Component {
                 label={<FormattedMessage id="ui-licenses.prop.endDate" />}
                 component={Datepicker}
                 dateFormat="YYYY-MM-DD"
-                backendDateStandard="YYYY-MM-DD"
                 disabled={this.state.openEnded}
                 validate={this.validateEndDate}
                 warn={this.warnEndDate}


### PR DESCRIPTION
We used to have to send back just the date string bc the backend didn't support the full ISO datetime strings but now it does. This also fixes an issue like we had with ERM-262.