### PR TITLE
Adding a note to a license term without setting a term value fails sh…

### DIFF
--- a/src/components/LicenseForm/LicenseForm.js
+++ b/src/components/LicenseForm/LicenseForm.js
@@ -39,6 +39,7 @@ class LicenseForm extends React.Component {
     isLoading: PropTypes.bool,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
+    stripes: PropTypes.object,
     submitting: PropTypes.bool,
   }
 

--- a/src/components/LicenseForm/LicenseForm.js
+++ b/src/components/LicenseForm/LicenseForm.js
@@ -56,7 +56,7 @@ class LicenseForm extends React.Component {
   }
 
   getSectionProps(id) {
-    const { data, handlers } = this.props;
+    const { data, handlers, stripes } = this.props;
 
     return {
       data,
@@ -64,6 +64,7 @@ class LicenseForm extends React.Component {
       id,
       onToggle: this.handleSectionToggle,
       open: this.state.sections[id],
+      stripes,
     };
   }
 

--- a/src/components/LicenseForm/LicenseForm.js
+++ b/src/components/LicenseForm/LicenseForm.js
@@ -39,7 +39,6 @@ class LicenseForm extends React.Component {
     isLoading: PropTypes.bool,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
-    stripes: PropTypes.object,
     submitting: PropTypes.bool,
   }
 
@@ -57,7 +56,7 @@ class LicenseForm extends React.Component {
   }
 
   getSectionProps(id) {
-    const { data, handlers, stripes } = this.props;
+    const { data, handlers } = this.props;
 
     return {
       data,
@@ -65,7 +64,6 @@ class LicenseForm extends React.Component {
       id,
       onToggle: this.handleSectionToggle,
       open: this.state.sections[id],
-      stripes,
     };
   }
 

--- a/src/components/LicenseForm/LicenseForm.js
+++ b/src/components/LicenseForm/LicenseForm.js
@@ -40,6 +40,7 @@ class LicenseForm extends React.Component {
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
     submitting: PropTypes.bool,
+    invalid: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -133,7 +134,7 @@ class LicenseForm extends React.Component {
         <Button
           id={id}
           type="submit"
-          disabled={this.props.pristine || this.props.submitting}
+          disabled={this.props.pristine || this.props.submitting || this.props.invalid}
           onClick={this.props.handleSubmit}
           buttonStyle="primary paneHeaderNewButton"
           marginBottom0

--- a/src/components/LicenseForm/LicenseForm.js
+++ b/src/components/LicenseForm/LicenseForm.js
@@ -117,8 +117,7 @@ class LicenseForm extends React.Component {
   }
 
   renderLastMenu() {
-    const { initialValues } = this.props;
-
+    const { initialValues, pristine, submitting, invalid } = this.props;
     let id;
     let label;
     if (initialValues && initialValues.id) {
@@ -134,7 +133,7 @@ class LicenseForm extends React.Component {
         <Button
           id={id}
           type="submit"
-          disabled={this.props.pristine || this.props.submitting || this.props.invalid}
+          disabled={pristine || submitting || invalid}
           onClick={this.props.handleSubmit}
           buttonStyle="primary paneHeaderNewButton"
           marginBottom0

--- a/src/components/formSections/FormTerms.js
+++ b/src/components/formSections/FormTerms.js
@@ -56,19 +56,21 @@ class FormTerms extends React.Component {
   }
 
   validate = (values) => {
-    let error;
+    const errors = {};
     if (!isEmpty(values)) {
+      errors.customProperties = {};
       Object.keys(values).forEach(key => {
         const val = values[key];
         if (val !== '') {
           const { note, value } = val[0];
           if (note && !value) {
-            error = true;
+            const error = { [key]: [{ 'value': { err: <FormattedMessage id="ui-licenses.errors.termNoteWithoutValue" /> } }] };
+            errors.customProperties = { ...errors.customProperties, ...error };
           }
         }
       });
     }
-    return error;
+    return (isEmpty(errors) || isEmpty(errors.customProperties)) ? undefined : errors;
   };
 
   render() {

--- a/src/components/formSections/FormTerms.js
+++ b/src/components/formSections/FormTerms.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
-import { get, isEmpty } from 'lodash';
+import { get } from 'lodash';
 import { Field } from 'redux-form';
 import {
   Accordion,
@@ -23,8 +23,12 @@ class FormTerms extends React.Component {
     }),
   };
 
-  state = {
-    terms: [],
+  constructor(props) {
+    super(props);
+    this.state = {
+      isCustomPropertiesError: false,
+      terms: [],
+    };
   }
 
   static getDerivedStateFromProps(props, state) {
@@ -55,22 +59,12 @@ class FormTerms extends React.Component {
     return null;
   }
 
-  validate = (values) => {
-    const errors = {};
-    if (!isEmpty(values)) {
-      errors.customProperties = {};
-      Object.keys(values).forEach(key => {
-        const val = values[key];
-        if (val !== '') {
-          const { note, value } = val[0];
-          if (note && !value) {
-            const error = { [key]: [{ 'value': { err: <FormattedMessage id="ui-licenses.errors.termNoteWithoutValue" /> } }] };
-            errors.customProperties = { ...errors.customProperties, ...error };
-          }
-        }
-      });
-    }
-    return (isEmpty(errors) || isEmpty(errors.customProperties)) ? undefined : errors;
+  handleError = () => {
+    this.setState(prevState => ({ isCustomPropertiesError: !prevState.isCustomPropertiesError }));
+  }
+
+  validate = () => {
+    return this.state.isCustomPropertiesError;
   };
 
   render() {
@@ -102,6 +96,7 @@ class FormTerms extends React.Component {
           component={TermsListField}
           availableTerms={this.state.terms}
           validate={this.validate}
+          onError={this.handleError}
         />
       </Accordion>
     );

--- a/src/components/formSections/FormTerms.js
+++ b/src/components/formSections/FormTerms.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
-import { get } from 'lodash';
+import { get, isEmpty } from 'lodash';
 import { Field } from 'redux-form';
+import { stopSubmit, setSubmitFailed, SubmissionError } from 'redux-form';
+
 
 import {
   Accordion,
@@ -27,6 +29,23 @@ class FormTerms extends React.Component {
   state = {
     terms: [],
   }
+
+
+ validation = (value) => {
+    let error;
+    if (!isEmpty(value)) {
+      Object.keys(value).forEach(key => {
+        let val = value[key];
+        if (val != '') {
+          const { note, value } = val[0];
+          if (note && !value) {
+            error = true;
+          }
+        }
+      });
+    } 
+    return error;
+  };
 
   static getDerivedStateFromProps(props, state) {
     const { terms } = props.data;
@@ -56,9 +75,9 @@ class FormTerms extends React.Component {
     return null;
   }
 
+ 
   render() {
-    const { id, onToggle, open } = this.props;
-
+    const { id, onToggle, open, stripes } = this.props;
     return (
       <Accordion
         id={id}
@@ -85,6 +104,8 @@ class FormTerms extends React.Component {
           name="customProperties"
           component={TermsListField}
           availableTerms={this.state.terms}
+          stripes={stripes}
+          validate={this.validation}
         />
       </Accordion>
     );

--- a/src/components/formSections/FormTerms.js
+++ b/src/components/formSections/FormTerms.js
@@ -21,7 +21,6 @@ class FormTerms extends React.Component {
     data: PropTypes.shape({
       terms: PropTypes.array,
     }),
-    stripes: PropTypes.object,
   };
 
   state = {
@@ -73,7 +72,7 @@ class FormTerms extends React.Component {
   };
 
   render() {
-    const { id, onToggle, open, stripes } = this.props;
+    const { id, onToggle, open } = this.props;
     return (
       <Accordion
         id={id}
@@ -100,7 +99,6 @@ class FormTerms extends React.Component {
           name="customProperties"
           component={TermsListField}
           availableTerms={this.state.terms}
-          stripes={stripes}
           validate={this.validate}
         />
       </Accordion>

--- a/src/components/formSections/FormTerms.js
+++ b/src/components/formSections/FormTerms.js
@@ -3,9 +3,6 @@ import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import { get, isEmpty } from 'lodash';
 import { Field } from 'redux-form';
-import { stopSubmit, setSubmitFailed, SubmissionError } from 'redux-form';
-
-
 import {
   Accordion,
   Col,
@@ -24,28 +21,12 @@ class FormTerms extends React.Component {
     data: PropTypes.shape({
       terms: PropTypes.array,
     }),
+    stripes: PropTypes.object,
   };
 
   state = {
     terms: [],
   }
-
-
- validation = (value) => {
-    let error;
-    if (!isEmpty(value)) {
-      Object.keys(value).forEach(key => {
-        let val = value[key];
-        if (val != '') {
-          const { note, value } = val[0];
-          if (note && !value) {
-            error = true;
-          }
-        }
-      });
-    } 
-    return error;
-  };
 
   static getDerivedStateFromProps(props, state) {
     const { terms } = props.data;
@@ -75,7 +56,22 @@ class FormTerms extends React.Component {
     return null;
   }
 
- 
+  validate = (values) => {
+    let error;
+    if (!isEmpty(values)) {
+      Object.keys(values).forEach(key => {
+        const val = values[key];
+        if (val !== '') {
+          const { note, value } = val[0];
+          if (note && !value) {
+            error = true;
+          }
+        }
+      });
+    }
+    return error;
+  };
+
   render() {
     const { id, onToggle, open, stripes } = this.props;
     return (
@@ -105,7 +101,7 @@ class FormTerms extends React.Component {
           component={TermsListField}
           availableTerms={this.state.terms}
           stripes={stripes}
-          validate={this.validation}
+          validate={this.validate}
         />
       </Accordion>
     );

--- a/src/components/formSections/FormTerms.js
+++ b/src/components/formSections/FormTerms.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage, injectIntl, intlShape } from 'react-intl';
 import { get } from 'lodash';
-import { stripesConnect } from '@folio/stripes/core';
+import { withStripes } from '@folio/stripes/core';
 import compose from 'compose-function';
 
 import {
@@ -63,12 +63,12 @@ class FormTerms extends React.Component {
     return null;
   }
 
-  handleError = (error) => {
+  handleError = (error, fieldName, formName) => {
     const { stripes: { store } } = this.props;
     // stopSubmit reports the error to redux-form and sets invalid flag to true which helps us in disabling the submit button
     if (error) {
-      store.dispatch(stopSubmit('EditLicense', { 'customProperties': error }));
-      store.dispatch(setSubmitFailed('EditLicense', 'customProperties'));
+      store.dispatch(stopSubmit(formName, { [fieldName]: error }));
+      store.dispatch(setSubmitFailed(formName, fieldName));
     }
   }
 
@@ -109,5 +109,5 @@ class FormTerms extends React.Component {
 
 export default compose(
   injectIntl,
-  stripesConnect
+  withStripes
 )(FormTerms);

--- a/src/components/formSections/components/TermsListField.js
+++ b/src/components/formSections/components/TermsListField.js
@@ -122,26 +122,12 @@ export default class TermsListField extends React.Component {
   validateNoteField = (values, termValue) => {
     const val = values ? values[termValue] : [];
     const { note, value } = val ? val[0] : {};
-    if (note && !value) {
-      return {
-        customProperties: {
-          [termValue]: [{ 'value': <FormattedMessage id="ui-licenses.terms.termNoteWithoutValue" /> }]
-        }
-      };
-    } else {
-      return undefined;
-    }
+    return (note && !value) ? true : undefined;
   }
 
-  renderTermValue = (term, i) => {
+  renderTermValue = (term, i, errorMessage) => {
     const { input: { onChange, value } } = this.props;
     const currentValue = value[term.value] ? value[term.value][0] : {};
-    let errorMessage;
-    const err = this.validateNoteField(value, term.value);
-    if (err) {
-      this.props.onError(err);
-      errorMessage = <FormattedMessage id="ui-licenses.terms.termNoteWithoutValue" />;
-    }
 
     // Initialise to just the value (for text/number values)
     // and then check if it's an object (for Select/refdata values).
@@ -266,29 +252,49 @@ export default class TermsListField extends React.Component {
     );
   }
 
+  renderTermsField = () => {
+    let termNoteError = false;
+    const { terms } = this.state;
+    return terms.map((term, i) => {
+      const { input: { value } } = this.props;
+      const err = this.validateNoteField(value, term.value);
+      let errorMessage;
+      if (err) {
+        errorMessage = <FormattedMessage id="ui-licenses.terms.termNoteWithoutValue" />;
+        termNoteError = true;
+      }
+      // At this point the all the terms in the state would have completed one loop
+      if (i === terms.length - 1) {
+        this.props.onError(termNoteError);
+      }
+
+      return (
+        <React.Fragment key={term.value}>
+          <Row>
+            <Col xs={5}>
+              {this.renderTermName(term, i)}
+            </Col>
+            <Col xs={6}>
+              {this.renderTermValue(term, i, errorMessage)}
+            </Col>
+            <Col xs={1}>
+              {this.renderTermDelete(term, i)}
+            </Col>
+          </Row>
+          <Row>
+            <Col xs={6} xsOffset={5}>
+              {this.renderTermNote(term, i)}
+            </Col>
+          </Row>
+        </React.Fragment>
+      );
+    });
+  }
+
   render() {
     return (
       <div>
-        { this.state.terms.map((term, i) => (
-          <React.Fragment key={term.value}>
-            <Row>
-              <Col xs={5}>
-                {this.renderTermName(term, i)}
-              </Col>
-              <Col xs={6}>
-                { this.renderTermValue(term, i) }
-              </Col>
-              <Col xs={1}>
-                {this.renderTermDelete(term, i)}
-              </Col>
-            </Row>
-            <Row>
-              <Col xs={6} xsOffset={5}>
-                {this.renderTermNote(term, i)}
-              </Col>
-            </Row>
-          </React.Fragment>
-        ))}
+        {this.renderTermsField()}
         {this.renderAddTerm()}
       </div>
     );

--- a/src/components/formSections/components/TermsListField.js
+++ b/src/components/formSections/components/TermsListField.js
@@ -123,13 +123,13 @@ export default class TermsListField extends React.Component {
   validateNoteField = (values, termValue) => {
     const val = values ? values[termValue] : [];
     const { note, value } = val ? val[0] : {};
-    if(note && !value) return <FormattedMessage id="ui-licenses.terms.setValue" />
+    if (note && !value) return <FormattedMessage id="ui-licenses.terms.setValue" />;
     else return undefined;
   }
 
 
   renderTermValue = (term, i) => {
-    const { input: { onChange, value, name } } = this.props;
+    const { input: { onChange, value } } = this.props;
     const currentValue = value[term.value] ? value[term.value][0] : {};
 
     // Initialise to just the value (for text/number values)
@@ -163,7 +163,7 @@ export default class TermsListField extends React.Component {
       });
     };
 
-    const err = this.validateNoteField(value, term.value);  
+    const err = this.validateNoteField(value, term.value);
     return (
       <FieldComponent
         data-test-term-value
@@ -257,7 +257,6 @@ export default class TermsListField extends React.Component {
   }
 
   render() {
-    
     return (
       <div>
         { this.state.terms.map((term, i) => (

--- a/src/components/formSections/components/TermsListField.js
+++ b/src/components/formSections/components/TermsListField.js
@@ -123,7 +123,7 @@ export default class TermsListField extends React.Component {
   validateNoteField = (values, termValue) => {
     const val = values ? values[termValue] : [];
     const { note, value } = val ? val[0] : {};
-    if (note && !value) return <FormattedMessage id="ui-licenses.terms.setValue" />;
+    if (note && !value) return <FormattedMessage id="ui-licenses.errors.termNoteWithoutValue" />;
     else return undefined;
   }
 

--- a/src/components/formSections/components/TermsListField.js
+++ b/src/components/formSections/components/TermsListField.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
-import { isEmpty } from 'lodash';
-
 import {
   Button,
   Col,
@@ -13,7 +11,6 @@ import {
   TextArea,
   TextField,
 } from '@folio/stripes/components';
-
 
 const TERM_TYPE_TEXT = 'com.k_int.web.toolkit.custprops.types.CustomPropertyText'; // eslint-disable-line no-unused-vars
 const TERM_TYPE_NUMBER = 'com.k_int.web.toolkit.custprops.types.CustomPropertyInteger';
@@ -34,6 +31,7 @@ export default class TermsListField extends React.Component {
       type: PropTypes.string.isRequired,
       value: PropTypes.string.isRequired,
     })).isRequired,
+    onError: PropTypes.func(),
   };
 
   state = {
@@ -121,20 +119,28 @@ export default class TermsListField extends React.Component {
     );
   }
 
+  validateNoteField = (values, termValue) => {
+    const val = values ? values[termValue] : [];
+    const { note, value } = val ? val[0] : {};
+    if (note && !value) {
+      return {
+        customProperties: {
+          [termValue]: [{ 'value': <FormattedMessage id="ui-licenses.terms.termNoteWithoutValue" /> }]
+        }
+      };
+    } else {
+      return undefined;
+    }
+  }
+
   renderTermValue = (term, i) => {
     const { input: { onChange, value } } = this.props;
     const currentValue = value[term.value] ? value[term.value][0] : {};
-    const { meta: { error } } = this.props;
-    const termValue = term.value;
-    let errorMsg;
-
-    if (error && !isEmpty(currentValue)) {
-      const errorKeysArray = Object.keys(error.customProperties);
-      if (errorKeysArray.includes(termValue)) {
-        const errorObj = error.customProperties[termValue][0];
-        const { value: { err } } = errorObj;
-        errorMsg = err;
-      }
+    let errorMessage;
+    const err = this.validateNoteField(value, term.value);
+    if (err) {
+      this.props.onError(err);
+      errorMessage = <FormattedMessage id="ui-licenses.terms.termNoteWithoutValue" />;
     }
 
     // Initialise to just the value (for text/number values)
@@ -174,7 +180,7 @@ export default class TermsListField extends React.Component {
         id={`edit-term-${i}-value`}
         onChange={handleChange}
         value={controlledFieldValue}
-        error={errorMsg}
+        error={errorMessage}
         {...fieldProps}
       />
     );

--- a/src/components/formSections/components/TermsListField.js
+++ b/src/components/formSections/components/TermsListField.js
@@ -122,7 +122,7 @@ export default class TermsListField extends React.Component {
   validateNoteField = (values, termValue) => {
     const val = values ? values[termValue] : [];
     const { note, value } = val ? val[0] : {};
-    return (note && !value) ? true : undefined;
+    return (note && !value) ? <FormattedMessage id="ui-licenses.terms.termNoteWithoutValue" /> : undefined;
   }
 
   renderTermValue = (term, i, errorMessage) => {
@@ -255,19 +255,10 @@ export default class TermsListField extends React.Component {
   renderTermsField = () => {
     let termNoteError = false;
     const { terms } = this.state;
-    return terms.map((term, i) => {
-      const { input: { value } } = this.props;
-      const err = this.validateNoteField(value, term.value);
-      let errorMessage;
-      if (err) {
-        errorMessage = <FormattedMessage id="ui-licenses.terms.termNoteWithoutValue" />;
-        termNoteError = true;
-      }
-      // At this point the all the terms in the state would have completed one loop
-      if (i === terms.length - 1) {
-        this.props.onError(termNoteError);
-      }
-
+    const { input: { value, name }, onError, meta: { form } } = this.props;
+    const termsFieldMap = terms.map((term, i) => {
+      const errorMessage = this.validateNoteField(value, term.value);
+      termNoteError = errorMessage ? true : termNoteError;
       return (
         <React.Fragment key={term.value}>
           <Row>
@@ -289,6 +280,8 @@ export default class TermsListField extends React.Component {
         </React.Fragment>
       );
     });
+    onError(termNoteError, name, form);
+    return termsFieldMap;
   }
 
   render() {

--- a/src/components/formSections/components/TermsListField.js
+++ b/src/components/formSections/components/TermsListField.js
@@ -120,8 +120,16 @@ export default class TermsListField extends React.Component {
     );
   }
 
+  validateNoteField = (values, termValue) => {
+    const val = values ? values[termValue] : [];
+    const { note, value } = val ? val[0] : {};
+    if(note && !value) return <FormattedMessage id="ui-licenses.terms.setValue" />
+    else return undefined;
+  }
+
+
   renderTermValue = (term, i) => {
-    const { input: { onChange, value } } = this.props;
+    const { input: { onChange, value, name } } = this.props;
     const currentValue = value[term.value] ? value[term.value][0] : {};
 
     // Initialise to just the value (for text/number values)
@@ -155,12 +163,14 @@ export default class TermsListField extends React.Component {
       });
     };
 
+    const err = this.validateNoteField(value, term.value);  
     return (
       <FieldComponent
         data-test-term-value
         id={`edit-term-${i}-value`}
         onChange={handleChange}
         value={controlledFieldValue}
+        error={err}
         {...fieldProps}
       />
     );
@@ -247,6 +257,7 @@ export default class TermsListField extends React.Component {
   }
 
   render() {
+    
     return (
       <div>
         { this.state.terms.map((term, i) => (

--- a/src/components/formSections/components/TermsListField.js
+++ b/src/components/formSections/components/TermsListField.js
@@ -31,7 +31,7 @@ export default class TermsListField extends React.Component {
       type: PropTypes.string.isRequired,
       value: PropTypes.string.isRequired,
     })).isRequired,
-    onError: PropTypes.func(),
+    onError: PropTypes.func,
   };
 
   state = {

--- a/src/components/formSections/components/TermsListField.js
+++ b/src/components/formSections/components/TermsListField.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { isEmpty } from 'lodash';
 
 import {
   Button,
@@ -120,17 +121,21 @@ export default class TermsListField extends React.Component {
     );
   }
 
-  validateNoteField = (values, termValue) => {
-    const val = values ? values[termValue] : [];
-    const { note, value } = val ? val[0] : {};
-    if (note && !value) return <FormattedMessage id="ui-licenses.errors.termNoteWithoutValue" />;
-    else return undefined;
-  }
-
-
   renderTermValue = (term, i) => {
     const { input: { onChange, value } } = this.props;
     const currentValue = value[term.value] ? value[term.value][0] : {};
+    const { meta: { error } } = this.props;
+    const termValue = term.value;
+    let errorMsg;
+
+    if (error && !isEmpty(currentValue)) {
+      const errorKeysArray = Object.keys(error.customProperties);
+      if (errorKeysArray.includes(termValue)) {
+        const errorObj = error.customProperties[termValue][0];
+        const { value: { err } } = errorObj;
+        errorMsg = err;
+      }
+    }
 
     // Initialise to just the value (for text/number values)
     // and then check if it's an object (for Select/refdata values).
@@ -163,14 +168,13 @@ export default class TermsListField extends React.Component {
       });
     };
 
-    const err = this.validateNoteField(value, term.value);
     return (
       <FieldComponent
         data-test-term-value
         id={`edit-term-${i}-value`}
         onChange={handleChange}
         value={controlledFieldValue}
-        error={err}
+        error={errorMsg}
         {...fieldProps}
       />
     );

--- a/src/routes/EditLicenseRoute.js
+++ b/src/routes/EditLicenseRoute.js
@@ -168,7 +168,7 @@ class EditLicenseRoute extends React.Component {
   }
 
   render() {
-    const { handlers, resources } = this.props;
+    const { handlers, resources, stripes } = this.props;
 
     if (!this.state.hasPerms) return <NoPermissions />;
 
@@ -190,6 +190,7 @@ class EditLicenseRoute extends React.Component {
         initialValues={this.getInitialValues()}
         isLoading={this.fetchIsPending()}
         onSubmit={this.handleSubmit}
+        stripes={stripes}
       />
     );
   }

--- a/src/routes/EditLicenseRoute.js
+++ b/src/routes/EditLicenseRoute.js
@@ -168,7 +168,7 @@ class EditLicenseRoute extends React.Component {
   }
 
   render() {
-    const { handlers, resources, stripes } = this.props;
+    const { handlers, resources } = this.props;
 
     if (!this.state.hasPerms) return <NoPermissions />;
 
@@ -190,7 +190,6 @@ class EditLicenseRoute extends React.Component {
         initialValues={this.getInitialValues()}
         isLoading={this.fetchIsPending()}
         onSubmit={this.handleSubmit}
-        stripes={stripes}
       />
     );
   }

--- a/translations/ui-licenses/en.json
+++ b/translations/ui-licenses/en.json
@@ -85,6 +85,7 @@
   "supplementaryDocs.none": "No supplementary documents have been added",
 
   "terms.add": "Add term",
+  "terms.setValue": "A value must be set for this term in order to save a note",
 
   "warn.clearEndDate": "End date will be cleared because \"Open ended\" is checked."
 }

--- a/translations/ui-licenses/en.json
+++ b/translations/ui-licenses/en.json
@@ -30,6 +30,7 @@
 
   "errors.endDateGreaterThanStartDate": "End date must be after the start date.",
   "errors.multipleLicensors": "Only one Licensor per license is allowed.",
+  "errors.termNoteWithoutValue": "A value must be set for this term in order to save a note",
 
   "filters.organization": "Organizations",
   "filters.organizationRole": "Organization role",
@@ -85,7 +86,6 @@
   "supplementaryDocs.none": "No supplementary documents have been added",
 
   "terms.add": "Add term",
-  "terms.setValue": "A value must be set for this term in order to save a note",
 
   "warn.clearEndDate": "End date will be cleared because \"Open ended\" is checked."
 }


### PR DESCRIPTION
…ould throw a validation error, refs ERM-268

- Passed the validate handler to the _Field_ that renders the TermsListFields. It returns true or undefined based on wether the _value_ field is being left empty when a _note_ field is entered. This helps in blocking the submission of the form

- The logic to pass down the _error_ lies inside the _renderTermValue_ function, which sends down the error to the appropriate _term_ Field.