### PR TITLE
Fixed ID for license contacts test

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint": "eslint src"
   },
   "devDependencies": {
-    "@folio/eslint-config-stripes": "^3.2.1",
+    "@folio/eslint-config-stripes": "^4.2.0",
     "@folio/stripes": "^2.0.0",
     "@folio/stripes-cli": "^1.8.0",
     "babel-eslint": "^9.0.0",

--- a/test/ui-testing/contacts.js
+++ b/test/ui-testing/contacts.js
@@ -54,7 +54,7 @@ module.exports.test = (uiTestCtx) => {
       CONTACTS.forEach((contact, row) => {
         it('should add contact', done => {
           nightmare
-            .click('#add-license-contacts-btn')
+            .click('#add-contacts-btn')
             .evaluate((r) => {
               if (!document.querySelector(`#contacts-user-${r}-search-button`)) {
                 throw Error('Expected user picker button to exist.');


### PR DESCRIPTION
[Necessary because of this change.](https://github.com/folio-org/stripes-erm-components/pull/101/files#diff-011d351e3d764dd491d904f806aa0826L174) `license` should've never been hardcoded into it.