### PR TITLE
Fixed tests

### DIFF
--- a/test/ui-testing/docs.js
+++ b/test/ui-testing/docs.js
@@ -25,7 +25,7 @@ module.exports.test = (uiTestCtx,
         helpers.clickApp(nightmare, done, 'licenses');
       });
 
-      it('should navigate to create license page and expand docs section', done => {
+      it('should navigate to create license page', done => {
         const name = `Docs License #${generateNumber()}`;
 
         console.log(`\tCreating ${name}`);
@@ -65,6 +65,7 @@ module.exports.test = (uiTestCtx,
         nightmare
           .click('#clickable-create-license')
           .waitUntilNetworkIdle(2000) // Wait for record to be fetched
+          .click('#clickable-expand-all')
           .then(done)
           .catch(done);
       });
@@ -77,7 +78,7 @@ module.exports.test = (uiTestCtx,
               if (!docCard) {
                 throw Error(`Could not find doc card with a doc named ${d.name}`);
               }
-              const name = docCard.querySelector('[data-test-doc-name]').innerText;
+              const name = docCard.querySelector('[data-test-doc-name]').innerText.trim();
               if (name !== d.name) {
                 throw Error(`Expected name to be ${d.name} and found ${name}.`);
               }
@@ -235,6 +236,7 @@ module.exports.test = (uiTestCtx,
         nightmare
           .click('#clickable-update-license')
           .waitUntilNetworkIdle(2000) // Wait for record to be fetched
+          .click('#clickable-expand-all')
           .then(done)
           .catch(done);
       });
@@ -247,7 +249,7 @@ module.exports.test = (uiTestCtx,
               if (!docCard) {
                 throw Error(`Could not find doc card with a doc named ${d.name}`);
               }
-              const name = docCard.querySelector('[data-test-doc-name]').innerText;
+              const name = docCard.querySelector('[data-test-doc-name]').innerText.trim();
               if (name !== d.name) {
                 throw Error(`Expected name to be ${d.name} and found ${name}.`);
               }

--- a/test/ui-testing/orgs.js
+++ b/test/ui-testing/orgs.js
@@ -78,8 +78,6 @@ module.exports.test = (uiTestCtx) => {
         it('should select org', done => {
           nightmare
             .click(`#orgs-nameOrg-${row}-search-button`)
-            .wait('#clickable-filter-status-active')
-            .click('#clickable-filter-status-active')
             .wait(`#list-plugin-find-organization [aria-rowindex="${row + 3}"] > a`)
             .click(`#list-plugin-find-organization [aria-rowindex="${row + 3}"] > a`)
             .waitUntilNetworkIdle(2000)
@@ -204,8 +202,6 @@ module.exports.test = (uiTestCtx) => {
                 .click(`#orgs-unlink-${row}`)
                 .wait(`#orgs-nameOrg-${row}-search-button`)
                 .click(`#orgs-nameOrg-${row}-search-button`)
-                .wait('#clickable-filter-status-active')
-                .click('#clickable-filter-status-active')
                 .wait('#list-plugin-find-organization [aria-rowindex="12"] > a')
                 .click('#list-plugin-find-organization [aria-rowindex="12"] > a')
                 .waitUntilNetworkIdle(2000)


### PR DESCRIPTION
- Orgs changed their default filter values
  - Stopped checking the 'Active' checkbox
- Accordion rendering got tweaked somehow so that the document elements were present but were not being filled with data.
  - Expanded all accordions before `evaluate`ing 