### PR TITLE
Terms Settings: Fixed enabled Save btn on mount

### DIFF
--- a/src/settings/components/TermsConfig/TermField.js
+++ b/src/settings/components/TermsConfig/TermField.js
@@ -1,8 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { FormattedMessage } from 'react-intl';
-
-import { Button } from '@folio/stripes/components';
 
 import TermFieldEdit from './TermFieldEdit';
 import TermFieldView from './TermFieldView';
@@ -16,11 +13,6 @@ export default class TermField extends React.Component {
         PropTypes.string,
       ]).isRequired,
     }).isRequired,
-    meta: PropTypes.shape({
-      invalid: PropTypes.bool,
-      pristine: PropTypes.bool,
-      submitting: PropTypes.bool,
-    }),
     mutators: PropTypes.shape({
       setTermValue: PropTypes.func.isRequired,
     }).isRequired,
@@ -69,65 +61,16 @@ export default class TermField extends React.Component {
       .then(() => this.setState({ editing: false }));
   }
 
-  renderActionButtons = () => {
-    const {
-      meta,
-      onDelete,
-    } = this.props;
-
-    const { editing } = this.state;
-
-    if (editing) {
-      return (
-        <span>
-          <Button
-            data-test-term-cancel-btn
-            marginBottom0
-            onClick={this.handleCancel}
-          >
-            <FormattedMessage id="stripes-core.button.cancel" />
-          </Button>
-          <Button
-            buttonStyle="primary"
-            data-test-term-save-btn
-            disabled={meta.invalid || meta.pristine || meta.submitting}
-            marginBottom0
-            onClick={this.handleSave}
-          >
-            <FormattedMessage id="stripes-core.button.save" />
-          </Button>
-        </span>
-      );
-    } else {
-      return (
-        <span>
-          <Button
-            buttonStyle="danger"
-            data-test-term-delete-btn
-            marginBottom0
-            onClick={onDelete}
-          >
-            <FormattedMessage id="stripes-core.button.delete" />
-          </Button>
-          <Button
-            marginBottom0
-            data-test-term-edit-btn
-            onClick={this.handleEdit}
-          >
-            <FormattedMessage id="stripes-core.button.edit" />
-          </Button>
-        </span>
-      );
-    }
-  }
-
   render() {
     const TermComponent = this.state.editing ? TermFieldEdit : TermFieldView;
 
     return (
       <TermComponent
         {...this.props}
-        actionButtons={this.renderActionButtons()}
+        onCancel={this.handleCancel}
+        onDelete={this.props.onDelete}
+        onSave={this.handleSave}
+        onEdit={this.handleEdit}
       />
     );
   }

--- a/src/settings/components/TermsConfig/TermFieldEdit.js
+++ b/src/settings/components/TermsConfig/TermFieldEdit.js
@@ -3,14 +3,13 @@ import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { Field } from 'react-final-form';
 
-import { Card, Col, InfoPopover, Row, Select, TextArea, TextField } from '@folio/stripes/components';
+import { Button, Card, Col, InfoPopover, Row, Select, TextArea, TextField } from '@folio/stripes/components';
 import { IntlConsumer } from '@folio/stripes/core';
 
 import { required } from '../../../util/validators';
 
 export default class TermFieldEdit extends React.Component {
   static propTypes = {
-    actionButtons: PropTypes.node.isRequired,
     input: PropTypes.shape({
       name: PropTypes.string.isRequired,
       value: PropTypes.shape({
@@ -22,6 +21,8 @@ export default class TermFieldEdit extends React.Component {
       pristine: PropTypes.bool,
       submitting: PropTypes.bool,
     }),
+    onCancel: PropTypes.func.isRequired,
+    onSave: PropTypes.func.isRequired,
     pickLists: PropTypes.arrayOf(PropTypes.object),
   }
 
@@ -31,8 +32,10 @@ export default class TermFieldEdit extends React.Component {
 
   render() {
     const {
-      actionButtons,
       input: { name, value },
+      meta,
+      onCancel,
+      onSave,
       pickLists,
     } = this.props;
 
@@ -48,7 +51,26 @@ export default class TermFieldEdit extends React.Component {
                   <FormattedMessage id="ui-licenses.settings.terms.newLicenseTerm" />}
               </strong>
             )}
-            headerEnd={actionButtons}
+            headerEnd={(
+              <span>
+                <Button
+                  data-test-term-cancel-btn
+                  marginBottom0
+                  onClick={onCancel}
+                >
+                  <FormattedMessage id="stripes-core.button.cancel" />
+                </Button>
+                <Button
+                  buttonStyle="primary"
+                  data-test-term-save-btn
+                  disabled={meta.invalid || meta.pristine || meta.submitting}
+                  marginBottom0
+                  onClick={onSave}
+                >
+                  <FormattedMessage id="stripes-core.button.save" />
+                </Button>
+              </span>
+            )}
           >
             <Row>
               <Col xs={6}>

--- a/src/settings/components/TermsConfig/TermFieldView.js
+++ b/src/settings/components/TermsConfig/TermFieldView.js
@@ -3,26 +3,21 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
-import { Card, Col, Row, KeyValue } from '@folio/stripes/components';
+import { Button, Card, Col, Row, KeyValue } from '@folio/stripes/components';
 
 const TYPE_CLASS_PREFIX = 'com.k_int.web.toolkit.custprops.types.CustomProperty';
 const REFDATA_CLASS_NAME = 'com.k_int.web.toolkit.custprops.types.CustomPropertyRefdata';
 
 export default class TermFieldView extends React.Component {
   static propTypes = {
-    actionButtons: PropTypes.node.isRequired,
     input: PropTypes.shape({
       name: PropTypes.string.isRequired,
       value: PropTypes.shape({
-        id: PropTypes.string,
         type: PropTypes.string,
       }).isRequired,
     }).isRequired,
-    meta: PropTypes.shape({
-      invalid: PropTypes.bool,
-      pristine: PropTypes.bool,
-      submitting: PropTypes.bool,
-    }),
+    onDelete: PropTypes.func.isRequired,
+    onEdit: PropTypes.func.isRequired,
     pickLists: PropTypes.arrayOf(PropTypes.object),
   }
 
@@ -40,15 +35,34 @@ export default class TermFieldView extends React.Component {
 
   render() {
     const {
-      actionButtons,
       input: { name, value },
+      onDelete,
+      onEdit,
     } = this.props;
 
     return (
       <Card
         data-test-term-name={name}
         headerStart={<strong><FormattedMessage id="ui-licenses.terms.term" /></strong>}
-        headerEnd={actionButtons}
+        headerEnd={(
+          <span>
+            <Button
+              buttonStyle="danger"
+              data-test-term-delete-btn
+              marginBottom0
+              onClick={onDelete}
+            >
+              <FormattedMessage id="stripes-core.button.delete" />
+            </Button>
+            <Button
+              marginBottom0
+              data-test-term-edit-btn
+              onClick={onEdit}
+            >
+              <FormattedMessage id="stripes-core.button.edit" />
+            </Button>
+          </span>
+        )}
       >
         <Row>
           <Col xs={6}>

--- a/src/settings/components/TermsConfig/TermsConfigListFieldArray.js
+++ b/src/settings/components/TermsConfig/TermsConfigListFieldArray.js
@@ -70,6 +70,11 @@ export default class TermsConfigListFieldArray extends React.Component {
               onDelete={() => this.handleDelete(i)}
               onSave={() => this.handleSave(i)}
               pickLists={pickLists}
+              // This `validate` appears stupid and like a no-op, but it's necessary because of the way
+              // that RFF decides whether to run validation: https://github.com/final-form/final-form/pull/267
+              // We want this Field to have validation info (meta.invalid) upon mount because some of the
+              // child Fields are required and they will run validation.
+              validate={() => {}}
             />
           ))
         }

--- a/src/settings/components/TermsConfig/TermsConfigListFieldArray.js
+++ b/src/settings/components/TermsConfig/TermsConfigListFieldArray.js
@@ -50,6 +50,10 @@ export default class TermsConfigListFieldArray extends React.Component {
   handleSave = (index) => {
     const term = this.props.fields.value[index];
 
+    if (!term.id) {
+      this.setState({ disableNewButton: false });
+    }
+
     return this.props.onSave(term);
   }
 

--- a/src/settings/components/TermsConfig/TermsConfigListFieldArray.js
+++ b/src/settings/components/TermsConfig/TermsConfigListFieldArray.js
@@ -20,6 +20,10 @@ export default class TermsConfigListFieldArray extends React.Component {
     pickLists: PropTypes.arrayOf(PropTypes.object),
   }
 
+  state = {
+    disableNewButton: false,
+  }
+
   defaultTermValue = {
     weight: 0,
     primary: false,
@@ -34,11 +38,13 @@ export default class TermsConfigListFieldArray extends React.Component {
       onDelete(term);
     } else {
       fields.remove(index);
+      this.setState({ disableNewButton: false });
     }
   }
 
   handleNew = () => {
     this.props.fields.unshift(this.defaultTermValue);
+    this.setState({ disableNewButton: true });
   }
 
   handleSave = (index) => {
@@ -54,7 +60,12 @@ export default class TermsConfigListFieldArray extends React.Component {
       <div>
         <Row end="sm">
           <Col>
-            <Button id="clickable-new-term" onClick={this.handleNew}>
+            <Button
+              buttonStyle="primary"
+              disabled={this.state.disableNewButton}
+              id="clickable-new-term"
+              onClick={this.handleNew}
+            >
               <FormattedMessage id="stripes-components.button.new" />
             </Button>
           </Col>
@@ -64,7 +75,7 @@ export default class TermsConfigListFieldArray extends React.Component {
             <Field
               component={TermField}
               isEqual={isEqual}
-              key={term.id || i}
+              key={term.id || 'new'}
               mutators={mutators}
               name={`${fields.name}[${i}]`}
               onDelete={() => this.handleDelete(i)}


### PR DESCRIPTION
A regression in final-form 4.18.5 (https://github.com/final-form/final-form/pull/267) resulted in nested fields not bubbling-up validation information to parent Fields.

I've filed an issue with final-form (https://github.com/final-form/final-form/issues/272) to see if this is intended or not, but this could be a workaround in the meanwhile.