### PR TITLE
Enabled save for invalid forms

### DIFF
--- a/src/components/AmendmentForm/AmendmentForm.js
+++ b/src/components/AmendmentForm/AmendmentForm.js
@@ -39,7 +39,6 @@ class AmendmentForm extends React.Component {
     }),
     isLoading: PropTypes.bool,
     initialValues: PropTypes.object,
-    invalid: PropTypes.bool,
     handleSubmit: PropTypes.func.isRequired,
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
@@ -119,7 +118,6 @@ class AmendmentForm extends React.Component {
       initialValues,
       pristine,
       submitting,
-      invalid
     } = this.props;
 
     let id;
@@ -143,7 +141,7 @@ class AmendmentForm extends React.Component {
     const endButton = (
       <Button
         buttonStyle="primary mega"
-        disabled={pristine || submitting || invalid}
+        disabled={pristine || submitting}
         id={id}
         marginBottom0
         onClick={handleSubmit}
@@ -174,41 +172,6 @@ class AmendmentForm extends React.Component {
             />
           )}
         </FormattedMessage>
-      </PaneMenu>
-    );
-  }
-
-  renderLastMenu() {
-    const {
-      handleSubmit,
-      initialValues,
-      pristine,
-      submitting,
-      invalid
-    } = this.props;
-
-    let id;
-    let label;
-    if (initialValues && initialValues.id) {
-      id = 'clickable-update-amendment';
-      label = <FormattedMessage id="ui-licenses.amendments.update" />;
-    } else {
-      id = 'clickable-create-amendment';
-      label = <FormattedMessage id="ui-licenses.amendments.create" />;
-    }
-
-    return (
-      <PaneMenu>
-        <Button
-          id={id}
-          type="submit"
-          disabled={pristine || submitting || invalid}
-          onClick={handleSubmit}
-          buttonStyle="primary paneHeaderNewButton"
-          marginBottom0
-        >
-          {label}
-        </Button>
       </PaneMenu>
     );
   }

--- a/src/components/LicenseForm/LicenseForm.js
+++ b/src/components/LicenseForm/LicenseForm.js
@@ -45,7 +45,6 @@ class LicenseForm extends React.Component {
     onSubmit: PropTypes.func.isRequired,
     pristine: PropTypes.bool,
     submitting: PropTypes.bool,
-    invalid: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -123,7 +122,6 @@ class LicenseForm extends React.Component {
       initialValues,
       pristine,
       submitting,
-      invalid
     } = this.props;
 
     let id;
@@ -147,7 +145,7 @@ class LicenseForm extends React.Component {
     const endButton = (
       <Button
         buttonStyle="primary mega"
-        disabled={pristine || submitting || invalid}
+        disabled={pristine || submitting}
         id={id}
         marginBottom0
         onClick={handleSubmit}

--- a/test/ui-testing/crud.js
+++ b/test/ui-testing/crud.js
@@ -42,7 +42,7 @@ const createLicense = (nightmare, done, defaultValues) => {
     .wait('#licenseInfo')
     .waitUntilNetworkIdle(500)
     .evaluate(expectedValues => {
-      const foundName = document.querySelector('[data-test-license-name]').innerText;
+      const foundName = document.querySelector('[data-test-license-name]').innerText.trim();
       if (foundName !== expectedValues.name) {
         throw Error(`Name of license is incorrect. Expected "${expectedValues.name}" and got "${foundName}" `);
       }
@@ -108,7 +108,7 @@ module.exports.test = (uiTestCtx) => {
           .wait('#licenseInfo')
           .waitUntilNetworkIdle(1000)
           .evaluate(expectedName => {
-            const foundName = document.querySelector('[data-test-license-name]').innerText;
+            const foundName = document.querySelector('[data-test-license-name]').innerText.trim();
             if (foundName !== expectedName) {
               throw Error(`Name of license is incorrect. Expected "${expectedName}" and got "${foundName}" `);
             }
@@ -152,7 +152,7 @@ module.exports.test = (uiTestCtx) => {
             const node = document.querySelector('[data-test-license-name]');
             if (!node || !node.innerText) throw Error('No license name node found.');
 
-            const name = node.innerText;
+            const name = node.innerText.trim();
             if (name !== expectedValues.name) {
               throw Error(`Name of found license is incorrect. Expected "${expectedValues.name}" and got "${name}" `);
             }
@@ -180,7 +180,7 @@ module.exports.test = (uiTestCtx) => {
           .wait('#licenseInfo')
           .waitUntilNetworkIdle(1000)
           .evaluate(expectedValues => {
-            const name = document.querySelector('[data-test-license-name]').innerText;
+            const name = document.querySelector('[data-test-license-name]').innerText.trim();
             if (name !== expectedValues.editedName) {
               throw Error(`Name of found license is incorrect. Expected "${expectedValues.editedName}" and got "${name}" `);
             }


### PR DESCRIPTION
Disabling save prevents fields that are added as invalid (eg, those that require a selection) from showing their error messages. This change was originally made in https://github.com/folio-org/ui-agreements/pull/292 and is being ported here for consistency.

Also did some integration test fixes (`trim()` is required after the switch to `Headline`) and cleanup.