### PR TITLE
ERM-477: New permissions model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 * Update stripes to v2.10.1 to support PaneFooter.
 * Move the Save & close button and add a Cancel button to Pane footer. ERM-412.
 * Apply the new large headline design to Licenses. ERM-260.
+* Added support for interface `licenses` version `2.0`.
+* Updated permission sets. ERM-477
 
 ## 3.5.0 2019-09-09
 * Added support for `mod-organizations-storage` 2.0

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
       },
       {
         "permissionName": "ui-licenses.licenses.delete",
-        "displayName": "Agreements: Delete licenses",
+        "displayName": "Licenses: Delete licenses",
         "visible": true,
         "subPermissions": [
           "ui-licenses.licenses.view",

--- a/package.json
+++ b/package.json
@@ -68,8 +68,10 @@
         "permissionName": "module.licenses.enabled",
         "displayName": "UI: ui-licenses module is enabled",
         "subPermissions": [
+          "configuration.entries.collection.get",
           "tags.collection.get",
-          "licenses.refdata.view"
+          "licenses.refdata.view",
+          "note.types.collection.get"
         ]
       },
       {
@@ -82,6 +84,7 @@
           "licenses.licenses.view",
           "licenses.files.view",
           "licenses.contacts.view",
+          "licenses.custprops.view",
           "licenses.orgs.view"
         ]
       },
@@ -105,6 +108,13 @@
         ]
       },
       {
+        "permissionName": "settings.licenses.enabled",
+        "displayName": "Settings (licenses): display list of settings pages",
+        "subPermissions": [
+          "settings.enabled"
+        ]
+      },
+      {
         "permissionName": "ui-licenses.picklists.manage",
         "displayName": "Licenses: Manage pick lists and values",
         "visible": true,
@@ -121,15 +131,6 @@
           "settings.licenses.enabled",
           "licenses.custprops.manage"
         ]
-      },
-      
-      {
-        "permissionName": "settings.licenses.enabled",
-        "displayName": "Settings (licenses): display list of settings pages",
-        "subPermissions": [
-          "settings.enabled"
-        ],
-        "visible": true
       }
     ],
     "icons": [

--- a/package.json
+++ b/package.json
@@ -68,26 +68,61 @@
         "permissionName": "module.licenses.enabled",
         "displayName": "UI: ui-licenses module is enabled",
         "subPermissions": [
-          "tags.collection.get"
+          "tags.collection.get",
+          "licenses.refdata.view"
         ]
       },
       {
         "permissionName": "ui-licenses.licenses.view",
-        "displayName": "Licenses: Can view licenses",
+        "displayName": "Licenses: Search & view licenses",
         "visible": true,
         "subPermissions": [
           "module.licenses.enabled",
-          "tags.item.post"
+          "tags.item.post",
+          "licenses.licenses.view",
+          "licenses.files.view",
+          "licenses.contacts.view",
+          "licenses.orgs.view"
         ]
       },
       {
         "permissionName": "ui-licenses.licenses.edit",
-        "displayName": "Licenses: Can create and edit licenses",
+        "displayName": "Licenses: Edit licenses",
         "visible": true,
         "subPermissions": [
-          "ui-licenses.licenses.view"
+          "ui-licenses.licenses.view",
+          "licenses.licenses.edit",
+          "licenses.files.edit"
         ]
       },
+      {
+        "permissionName": "ui-licenses.licenses.delete",
+        "displayName": "Agreements: Delete licenses",
+        "visible": true,
+        "subPermissions": [
+          "ui-licenses.licenses.view",
+          "licenses.licenses.item.delete"
+        ]
+      },
+      {
+        "permissionName": "ui-licenses.picklists.manage",
+        "displayName": "Licenses: Manage pick lists and values",
+        "visible": true,
+        "subPermissions": [
+          "settings.licenses.enabled",
+          "licenses.refdata.manage"
+        ]
+      },
+      {
+        "permissionName": "ui-licenses.terms.manage",
+        "displayName": "Licenses: Manage license terms",
+        "visible": true,
+        "subPermissions": [
+          "settings.licenses.enabled",
+          "licenses.custprops.manage"
+        ]
+      },
+      
       {
         "permissionName": "settings.licenses.enabled",
         "displayName": "Settings (licenses): display list of settings pages",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "hasSettings": true,
     "queryResource": "query",
     "okapiInterfaces": {
-      "licenses": "1.0",
+      "licenses": "1.0 2.0",
       "organizations-storage.interfaces": "2.0",
       "users": "13.0 14.0 15.0"
     },

--- a/src/settings/index.js
+++ b/src/settings/index.js
@@ -16,7 +16,7 @@ export default class LicenseSettings extends React.Component {
         {
           component: TermsConfigRoute,
           label: <FormattedMessage id="ui-licenses.section.terms" />,
-          perm: 'settings.licenses.enabled',
+          perm: 'ui-licenses.terms.manage',
           route: 'terms',
         }
       ]
@@ -27,13 +27,13 @@ export default class LicenseSettings extends React.Component {
         {
           component: PickListSettings,
           label: <FormattedMessage id="ui-licenses.settings.pickLists" />,
-          perm: 'settings.licenses.enabled',
+          perm: 'ui-licenses.picklists.manage',
           route: 'pick-lists',
         },
         {
           component: PickListValueSettings,
           label: <FormattedMessage id="ui-licenses.settings.pickListValues" />,
-          perm: 'settings.licenses.enabled',
+          perm: 'ui-licenses.picklists.manage',
           route: 'pick-list-values',
         },
       ]


### PR DESCRIPTION
Adds support for the licenses interface 2.0 which brings new permissions, that was merged in https://github.com/folio-org/mod-licenses/pull/105