### PR TITLE
ERM-636: Use Spinner and FormattedUTCDate from Stripes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-licenses
 
+## 3.7.0 IN PROGRESS
+* Switched to using `<FormattedUTCDate>` from Stripes. ERM-635
+* Switched to using `<Spinner>` from Stripes. ERM-635
+
 ## 3.6.0 2019-12-04
 * Port ui-licenses to RFF. ERM-487.
 * Update stripes to v2.10.1 to support PaneFooter.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@folio/eslint-config-stripes": "^4.2.0",
-    "@folio/stripes": "^2.10.1",
+    "@folio/stripes": "^2.12.0",
     "@folio/stripes-cli": "^1.8.0",
     "babel-eslint": "^9.0.0",
     "eslint": "^5.5.0"
@@ -49,7 +49,7 @@
     "redux-form": "^7.0.3"
   },
   "peerDependencies": {
-    "@folio/stripes": "^2.10.1",
+    "@folio/stripes": "^2.12.0",
     "react": "*"
   },
   "stripes": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/licenses",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "ERM License functionality for Stripes",
   "main": "src/index.js",
   "repository": "",

--- a/src/components/Amendment/Amendment.js
+++ b/src/components/Amendment/Amendment.js
@@ -12,11 +12,10 @@ import {
   Pane,
   PaneMenu,
   Row,
+  Spinner,
 } from '@folio/stripes/components';
 
 import { IfPermission, TitleManager } from '@folio/stripes/core';
-
-import { Spinner } from '@folio/stripes-erm-components';
 
 import {
   AmendmentInfo,

--- a/src/components/AmendmentForm/AmendmentForm.js
+++ b/src/components/AmendmentForm/AmendmentForm.js
@@ -2,6 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
 import { isEqual } from 'lodash';
+import setFieldData from 'final-form-set-field-data';
+
 import {
   AccordionSet,
   Button,
@@ -14,12 +16,10 @@ import {
   PaneMenu,
   Paneset,
   Row,
+  Spinner,
 } from '@folio/stripes/components';
 import { TitleManager } from '@folio/stripes/core';
 import stripesFinalForm from '@folio/stripes/final-form';
-import setFieldData from 'final-form-set-field-data';
-
-import { Spinner } from '@folio/stripes-erm-components';
 
 import {
   AmendmentFormInfo,

--- a/src/components/FormattedUTCDate/FormattedUTCDate.js
+++ b/src/components/FormattedUTCDate/FormattedUTCDate.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import { FormattedDate } from 'react-intl';
-
-export default function FormattedUTCDate(props) {
-  return <FormattedDate timeZone="UTC" {...props} />;
-}

--- a/src/components/FormattedUTCDate/index.js
+++ b/src/components/FormattedUTCDate/index.js
@@ -1,1 +1,0 @@
-export { default } from './FormattedUTCDate';

--- a/src/components/License/License.js
+++ b/src/components/License/License.js
@@ -15,9 +15,9 @@ import {
   Pane,
   PaneMenu,
   Row,
+  Spinner,
 } from '@folio/stripes/components';
 import { AppIcon, IfPermission, TitleManager } from '@folio/stripes/core';
-import { Spinner } from '@folio/stripes-erm-components';
 
 import {
   LicenseAgreements,

--- a/src/components/LicenseForm/LicenseForm.js
+++ b/src/components/LicenseForm/LicenseForm.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { FormattedMessage } from 'react-intl';
+import { isEqual } from 'lodash';
+import setFieldData from 'final-form-set-field-data';
+
 import {
   AccordionSet,
   Button,
@@ -13,12 +16,10 @@ import {
   PaneMenu,
   Paneset,
   Row,
+  Spinner,
 } from '@folio/stripes/components';
 import { AppIcon, TitleManager } from '@folio/stripes/core';
 import stripesFinalForm from '@folio/stripes/final-form';
-import { isEqual } from 'lodash';
-import setFieldData from 'final-form-set-field-data';
-import { Spinner } from '@folio/stripes-erm-components';
 
 import {
   LicenseFormInfo,

--- a/src/components/Licenses/Licenses.js
+++ b/src/components/Licenses/Licenses.js
@@ -5,13 +5,14 @@ import { noop } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
 import {
-  MultiColumnList,
-  SearchField,
-  Pane,
-  Icon,
   Button,
+  FormattedUTCDate,
+  Icon,
+  MultiColumnList,
+  Pane,
   PaneMenu,
   Paneset,
+  SearchField,
 } from '@folio/stripes/components';
 
 import { AppIcon, IfPermission } from '@folio/stripes/core';
@@ -24,7 +25,6 @@ import {
 
 import { LicenseEndDate } from '@folio/stripes-erm-components';
 
-import FormattedUTCDate from '../FormattedUTCDate';
 import LicenseFilters from '../LicenseFilters';
 
 import css from './Licenses.css';

--- a/src/components/viewSections/AmendmentInfo.js
+++ b/src/components/viewSections/AmendmentInfo.js
@@ -5,14 +5,13 @@ import { FormattedMessage } from 'react-intl';
 
 import {
   Col,
+  FormattedUTCDate,
   Headline,
   KeyValue,
   Row,
 } from '@folio/stripes/components';
 
 import { LicenseEndDate } from '@folio/stripes-erm-components';
-
-import FormattedUTCDate from '../FormattedUTCDate';
 
 export default class AmendmentInfo extends React.Component {
   static propTypes = {

--- a/src/components/viewSections/CoreDocs.js
+++ b/src/components/viewSections/CoreDocs.js
@@ -6,8 +6,9 @@ import {
   Accordion,
   Badge,
   Layout,
+  Spinner,
 } from '@folio/stripes/components';
-import { DocumentCard, Spinner } from '@folio/stripes-erm-components';
+import { DocumentCard } from '@folio/stripes-erm-components';
 
 export default class CoreDocs extends React.Component {
   static propTypes = {

--- a/src/components/viewSections/LicenseAgreements.js
+++ b/src/components/viewSections/LicenseAgreements.js
@@ -7,13 +7,12 @@ import { IfInterface } from '@folio/stripes/core';
 import {
   Accordion,
   Badge,
+  FormattedUTCDate,
   InfoPopover,
   Layout,
   MultiColumnList,
   Spinner,
 } from '@folio/stripes/components';
-
-import FormattedUTCDate from '../FormattedUTCDate';
 
 export default class LicenseAgreements extends React.Component {
   static propTypes = {

--- a/src/components/viewSections/LicenseAgreements.js
+++ b/src/components/viewSections/LicenseAgreements.js
@@ -10,8 +10,8 @@ import {
   InfoPopover,
   Layout,
   MultiColumnList,
+  Spinner,
 } from '@folio/stripes/components';
-import { Spinner } from '@folio/stripes-erm-components';
 
 import FormattedUTCDate from '../FormattedUTCDate';
 

--- a/src/components/viewSections/LicenseAmendments.js
+++ b/src/components/viewSections/LicenseAmendments.js
@@ -7,12 +7,11 @@ import {
   Accordion,
   Badge,
   Button,
+  FormattedUTCDate,
   MultiColumnList,
 } from '@folio/stripes/components';
 
 import { LicenseEndDate } from '@folio/stripes-erm-components';
-
-import FormattedUTCDate from '../FormattedUTCDate';
 
 export default class LicenseAmendments extends React.Component {
   static propTypes = {

--- a/src/components/viewSections/LicenseInternalContacts.js
+++ b/src/components/viewSections/LicenseInternalContacts.js
@@ -3,8 +3,8 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
 
-import { Accordion, Badge } from '@folio/stripes/components';
-import { InternalContactCard, Spinner } from '@folio/stripes-erm-components';
+import { Accordion, Badge, Spinner } from '@folio/stripes/components';
+import { InternalContactCard } from '@folio/stripes-erm-components';
 
 export default class LicenseInternalContacts extends React.Component {
   static propTypes = {

--- a/src/components/viewSections/SupplementaryDocs.js
+++ b/src/components/viewSections/SupplementaryDocs.js
@@ -6,8 +6,9 @@ import {
   Accordion,
   Badge,
   Layout,
+  Spinner,
 } from '@folio/stripes/components';
-import { DocumentCard, Spinner } from '@folio/stripes-erm-components';
+import { DocumentCard } from '@folio/stripes-erm-components';
 
 export default class SupplementaryDocs extends React.Component {
   static propTypes = {


### PR DESCRIPTION
Spinner and FormattedUTCDate were promoted to Stripes as of version 2.12.0 so we should switch to pulling them from there now.