### PR TITLE
ERM-566: Display small license icon for each row

### DIFF
--- a/src/components/Licenses/Licenses.js
+++ b/src/components/Licenses/Licenses.js
@@ -73,7 +73,7 @@ export default class Licenses extends React.Component {
         <AppIcon
           size="small"
           app="licenses"
-          iconKey={'app'}
+          iconKey="app"
         >
           {a.name}
         </AppIcon>

--- a/src/components/Licenses/Licenses.js
+++ b/src/components/Licenses/Licenses.js
@@ -68,6 +68,17 @@ export default class Licenses extends React.Component {
   }
 
   formatter = {
+    name: a => {
+      return (
+        <AppIcon
+          size="small"
+          app="licenses"
+          iconKey={'app'}
+        >
+          {a.name}
+        </AppIcon>
+      );
+    },
     type: ({ type }) => type && type.label,
     status: ({ status }) => status && status.label,
     startDate: ({ startDate }) => (startDate ? <FormattedUTCDate value={startDate} /> : ''),

--- a/src/routes/EditLicenseRoute.js
+++ b/src/routes/EditLicenseRoute.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { cloneDeep, difference, get } from 'lodash';
+import { cloneDeep, get } from 'lodash';
 import compose from 'compose-function';
 
 import { stripesConnect } from '@folio/stripes/core';


### PR DESCRIPTION
Small piece of work to mirror ui-agreements' icon per row, replaced with licenses