### PR TITLE
Retain focus on the optional term name, refs ERM-630

### DIFF
--- a/src/components/formSections/components/TermsListField.js
+++ b/src/components/formSections/components/TermsListField.js
@@ -86,9 +86,12 @@ export default class TermsListField extends React.Component {
       return false;
     });
 
+    const termValue = value[term.value];
+    const id = termValue ? termValue[0].id : null;
+
     return (
       <Select
-        autoFocus={isEmpty(term)}
+        autoFocus={!id}
         data-test-term-name
         dataOptions={[term, ...unsetTerms]} // The selected term, and the available unset terms
         id={`edit-term-${i}-name`}


### PR DESCRIPTION
Check if the `termValue` has an `id`and if it does, don't focus.