### PR TITLE
ERM-723, 724, 725: Add Callouts and Deletion confirmations

### DIFF
--- a/src/routes/CreateAmendmentRoute.js
+++ b/src/routes/CreateAmendmentRoute.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import compose from 'compose-function';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 
 import withFileHandlers from './components/withFileHandlers';

--- a/src/routes/CreateAmendmentRoute.js
+++ b/src/routes/CreateAmendmentRoute.js
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import compose from 'compose-function';
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
-import { stripesConnect } from '@folio/stripes/core';
+import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 
 import withFileHandlers from './components/withFileHandlers';
 import Form from '../components/AmendmentForm';
@@ -66,6 +67,8 @@ class CreateAmendmentRoute extends React.Component {
     handlers: {},
   }
 
+  static contextType = CalloutContext;
+
   getInitialValues = () => {
     const { resources } = this.props;
 
@@ -92,7 +95,7 @@ class CreateAmendmentRoute extends React.Component {
     const license = get(this.props.resources, 'license.records[0]', {});
     const originalAmendmentIds = {};
     (license.amendments || []).forEach(a => { originalAmendmentIds[a.id] = 1; });
-
+    const name = amendment?.name;
     this.props.mutator.license
       .PUT({
         ...license,
@@ -105,6 +108,7 @@ class CreateAmendmentRoute extends React.Component {
             newAmendmentId = a.id;
           }
         });
+        this.context.sendCallout({ message: <SafeHTMLMessage id="ui-licenses.amendments.create.callout" values={{ name }} /> });
         this.props.history.push(`/licenses/${match.params.id}/amendments/${newAmendmentId}${location.search}`);
       });
   }

--- a/src/routes/CreateLicenseRoute.js
+++ b/src/routes/CreateLicenseRoute.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import compose from 'compose-function';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 
 import withFileHandlers from './components/withFileHandlers';

--- a/src/routes/CreateLicenseRoute.js
+++ b/src/routes/CreateLicenseRoute.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import compose from 'compose-function';
 
-import { stripesConnect } from '@folio/stripes/core';
+import { ToastContext, stripesConnect } from '@folio/stripes/core';
 
 import withFileHandlers from './components/withFileHandlers';
 import View from '../components/LicenseForm';
@@ -80,6 +80,8 @@ class CreateLicenseRoute extends React.Component {
     handlers: {},
   }
 
+  static contextType = ToastContext;
+
   constructor(props) {
     super(props);
 
@@ -117,6 +119,8 @@ class CreateLicenseRoute extends React.Component {
     mutator.licenses
       .POST(license)
       .then(({ id }) => {
+        const callout = this.context;
+        callout.current.sendCallout({ message: 'Hello! New license!' });
         history.push(`/licenses/${id}${location.search}`);
       });
   }

--- a/src/routes/CreateLicenseRoute.js
+++ b/src/routes/CreateLicenseRoute.js
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import compose from 'compose-function';
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
-import { ToastContext, stripesConnect } from '@folio/stripes/core';
+import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 
 import withFileHandlers from './components/withFileHandlers';
 import View from '../components/LicenseForm';
@@ -80,7 +81,7 @@ class CreateLicenseRoute extends React.Component {
     handlers: {},
   }
 
-  static contextType = ToastContext;
+  static contextType = CalloutContext;
 
   constructor(props) {
     super(props);
@@ -115,12 +116,11 @@ class CreateLicenseRoute extends React.Component {
 
   handleSubmit = (license) => {
     const { history, location, mutator } = this.props;
-
+    const name = license?.name;
     mutator.licenses
       .POST(license)
       .then(({ id }) => {
-        const callout = this.context;
-        callout.current.sendCallout({ message: 'Hello! New license!' });
+        this.context.sendCallout({ message: <SafeHTMLMessage id="ui-licenses.create.callout" values={{ name }} /> });
         history.push(`/licenses/${id}${location.search}`);
       });
   }

--- a/src/routes/EditAmendmentRoute.js
+++ b/src/routes/EditAmendmentRoute.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { cloneDeep, get } from 'lodash';
 import compose from 'compose-function';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 
 import withFileHandlers from './components/withFileHandlers';

--- a/src/routes/EditAmendmentRoute.js
+++ b/src/routes/EditAmendmentRoute.js
@@ -2,8 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { cloneDeep, get } from 'lodash';
 import compose from 'compose-function';
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
-import { stripesConnect } from '@folio/stripes/core';
+import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 
 import withFileHandlers from './components/withFileHandlers';
 
@@ -68,6 +69,8 @@ class EditAmendmentRoute extends React.Component {
     handlers: {},
   }
 
+  static contextType = CalloutContext;
+
   state = {
     selectedAmendment: {}
   }
@@ -111,13 +114,16 @@ class EditAmendmentRoute extends React.Component {
 
   handleSubmit = (amendment) => {
     const license = get(this.props.resources, 'license.records[0]', {});
-
+    const name = amendment?.name;
     this.props.mutator.license
       .PUT({
         ...license,
         amendments: [amendment]
       })
-      .then(this.handleClose);
+      .then(() => {
+        this.context.sendCallout({ message: <SafeHTMLMessage id="ui-licenses.amendments.update.callout" values={{ name }} /> });
+        this.handleClose();
+      });
   }
 
   fetchIsPending = () => {

--- a/src/routes/EditLicenseRoute.js
+++ b/src/routes/EditLicenseRoute.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { cloneDeep, get } from 'lodash';
 import compose from 'compose-function';
 
-import { stripesConnect } from '@folio/stripes/core';
+import { ToastContext, stripesConnect } from '@folio/stripes/core';
 
 import withFileHandlers from './components/withFileHandlers';
 import Form from '../components/LicenseForm';
@@ -97,6 +97,8 @@ class EditLicenseRoute extends React.Component {
     handlers: {},
   }
 
+  static contextType = ToastContext;
+
   constructor(props) {
     super(props);
 
@@ -142,7 +144,11 @@ class EditLicenseRoute extends React.Component {
   handleSubmit = (license) => {
     this.props.mutator.license
       .PUT(license)
-      .then(this.handleClose);
+      .then(() => {
+        const callout = this.context;
+        callout.current.sendCallout({ message: 'Hello again! License updated!' });
+        this.handleClose();
+      });
   }
 
   fetchIsPending = () => {

--- a/src/routes/EditLicenseRoute.js
+++ b/src/routes/EditLicenseRoute.js
@@ -2,8 +2,8 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { cloneDeep, get } from 'lodash';
 import compose from 'compose-function';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 
 

--- a/src/routes/EditLicenseRoute.js
+++ b/src/routes/EditLicenseRoute.js
@@ -2,8 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { cloneDeep, get } from 'lodash';
 import compose from 'compose-function';
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
-import { ToastContext, stripesConnect } from '@folio/stripes/core';
+import { CalloutContext, stripesConnect } from '@folio/stripes/core';
+
 
 import withFileHandlers from './components/withFileHandlers';
 import Form from '../components/LicenseForm';
@@ -97,7 +99,7 @@ class EditLicenseRoute extends React.Component {
     handlers: {},
   }
 
-  static contextType = ToastContext;
+  static contextType = CalloutContext;
 
   constructor(props) {
     super(props);
@@ -142,11 +144,11 @@ class EditLicenseRoute extends React.Component {
   }
 
   handleSubmit = (license) => {
+    const name = license?.name;
     this.props.mutator.license
       .PUT(license)
       .then(() => {
-        const callout = this.context;
-        callout.current.sendCallout({ message: 'Hello again! License updated!' });
+        this.context.sendCallout({ message: <SafeHTMLMessage id="ui-licenses.update.callout" values={{ name }} /> });
         this.handleClose();
       });
   }

--- a/src/routes/ViewAmendmentRoute.js
+++ b/src/routes/ViewAmendmentRoute.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import compose from 'compose-function';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
-
-import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 import { FormattedMessage } from 'react-intl';
+
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
+import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 import { ConfirmationModal } from '@folio/stripes/components';
 
 import withFileHandlers from './components/withFileHandlers';
@@ -59,10 +59,7 @@ class ViewAmendmentsRoute extends React.Component {
 
   static contextType = CalloutContext;
 
-  constructor(props) {
-    super(props);
-    this.state = { showConfirmDelete: false };
-  }
+  state = { showConfirmDelete: false };
 
   getAmendment = () => {
     const { match, resources } = this.props;

--- a/src/routes/ViewAmendmentRoute.js
+++ b/src/routes/ViewAmendmentRoute.js
@@ -2,10 +2,10 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import compose from 'compose-function';
-
-import { stripesConnect } from '@folio/stripes/core';
-import { FormattedMessage } from 'react-intl';
 import SafeHTMLMessage from '@folio/react-intl-safe-html';
+
+import { CalloutContext, stripesConnect } from '@folio/stripes/core';
+import { FormattedMessage } from 'react-intl';
 import { ConfirmationModal } from '@folio/stripes/components';
 
 import withFileHandlers from './components/withFileHandlers';
@@ -57,6 +57,8 @@ class ViewAmendmentsRoute extends React.Component {
     handlers: {},
   }
 
+  static contextType = CalloutContext;
+
   constructor(props) {
     super(props);
     this.state = { showConfirmDelete: false };
@@ -79,6 +81,7 @@ class ViewAmendmentsRoute extends React.Component {
   handleDelete = () => {
     const license = get(this.props.resources, 'license.records[0]', {});
     const { match: { params } } = this.props;
+    const name = license?.amendments.filter(obj => obj.id === params?.amendmentId)[0]?.name;
 
     this.props.mutator.license
       .PUT({
@@ -88,7 +91,10 @@ class ViewAmendmentsRoute extends React.Component {
           _delete: true,
         }],
       })
-      .then(this.handleClose);
+      .then(() => {
+        this.context.sendCallout({ message: <SafeHTMLMessage id="ui-licenses.amendments.delete.callout" values={{ name }} /> });
+        this.handleClose();
+      });
   }
 
   showDeleteConfirmationModal = () => this.setState({ showConfirmDelete: true });

--- a/src/settings/components/TermsConfigForm.js
+++ b/src/settings/components/TermsConfigForm.js
@@ -25,13 +25,13 @@ class TermsConfigForm extends React.Component {
     pickLists: PropTypes.arrayOf(PropTypes.object),
   };
 
-  sendCallout = (operation, outcome, error = '') => {
+  sendCallout = (operation, outcome, error = '', custPropName = '') => {
     this.callout.sendCallout({
       type: outcome,
       message: (
-        <FormattedMessage
+        <SafeHTMLMessage
           id={`ui-licenses.terms.callout.${operation}.${outcome}`}
-          values={{ error }}
+          values={{ error, name: custPropName }}
         />
       ),
       timeout: error ? 0 : undefined, // Don't autohide callouts with a specified error message.
@@ -42,7 +42,7 @@ class TermsConfigForm extends React.Component {
     return this.callout.sendCallout({
       type: 'error',
       message: (
-        <SafeHTMLMessage id="ui-licenses.terms.callout.delete.termsInUse" />
+        <SafeHTMLMessage id="ui-licenses.terms.callout.delete.termInUse" />
       ),
       timeout: 0,
     });
@@ -51,7 +51,7 @@ class TermsConfigForm extends React.Component {
   handleDelete = customProperty => {
     return this.props
       .onDelete(customProperty)
-      .then(() => this.sendCallout('delete', 'success'))
+      .then(() => this.sendCallout('delete', 'success', '', customProperty.name))
       .catch(response => {
         // Attempt to show an error message if we got JSON back with a message.
         // If json()ification fails, show the generic error callout.
@@ -65,10 +65,10 @@ class TermsConfigForm extends React.Component {
             if (pattern.test(error.message)) {
               this.sendCalloutInUse();
             } else {
-              this.sendCallout('delete', 'error', error.message);
+              this.sendCallout('delete', 'error', error.message, customProperty?.name);
             }
           })
-          .catch(() => this.sendCallout('delete', 'error'));
+          .catch(() => this.sendCallout('delete', 'error', '', customProperty?.name));
 
         // Return a rejected promise to break any downstream Promise chains.
         return Promise.reject();
@@ -78,14 +78,14 @@ class TermsConfigForm extends React.Component {
   handleSave = customProperty => {
     return this.props
       .onSave(customProperty)
-      .then(() => this.sendCallout('save', 'success'))
+      .then(() => this.sendCallout('save', 'success', '', customProperty?.name))
       .catch(response => {
         // Attempt to show an error message if we got JSON back with a message.
         // If json()ification fails, show the generic error callout.
         response
           .json()
-          .then(error => this.sendCallout('save', 'error', error.message))
-          .catch(() => this.sendCallout('save', 'error'));
+          .then(error => this.sendCallout('save', 'error', error.message, customProperty?.name))
+          .catch(() => this.sendCallout('save', 'error', '', customProperty?.name));
 
         // Return a rejected promise to break any downstream Promise chains.
         return Promise.reject();

--- a/src/settings/components/TermsConfigForm.js
+++ b/src/settings/components/TermsConfigForm.js
@@ -2,9 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { get } from 'lodash';
 import { FormattedMessage } from 'react-intl';
-import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { FieldArray } from 'react-final-form-arrays';
 
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 import { Callout, Pane } from '@folio/stripes/components';
 import stripesFinalForm from '@folio/stripes/final-form';
 import { CustomPropertiesConfigListFieldArray } from '@folio/stripes-erm-components';

--- a/translations/ui-licenses/en.json
+++ b/translations/ui-licenses/en.json
@@ -10,6 +10,8 @@
   "closeEditLicense": "Close edit license pane",
   "createLicense": "Create license",
   "create": "Create",
+  "create.callout": "<strong>License created:</strong> {name}",
+  "update.callout": "<strong>License updated:</strong> {name}",
   "delete": "Delete",
   "editLicense": "Edit license",
   "edit": "Edit",
@@ -22,9 +24,12 @@
   "amendments.add": "Add amendment",
   "amendments.closePane": "Close edit amendment pane",
   "amendments.create": "Create amendment",
+  "amendments.create.callout": "<strong>Amendment created:</strong> {name}",
   "amendments.amendmentInfo": "Amendment information",
   "amendments.update": "Update amendment",
-
+  "amendments.update.callout": "<strong>Amendment updated:</strong> {name}",
+  
+  "amendments.delete.callout": "<strong>Amendment deleted:</strong> {name}",
   "amendments.delete.confirmLabel": "Delete",
   "amendments.delete.confirmHeading": "Delete amendment",
   "amendments.delete.confirmMessage": "Amendment <strong>{name}</strong> will be <strong>deleted</strong>.",

--- a/translations/ui-licenses/en.json
+++ b/translations/ui-licenses/en.json
@@ -105,11 +105,11 @@
 
   "terms.add": "Add term",
   "terms.count": "{count, number} saved {count, plural, one {term} other {terms}}",
-  "terms.callout.delete.error": "There was an error deleting the term. {error}",
-  "terms.callout.delete.success": "Term successfully deleted.",
-  "terms.callout.delete.termInUse": "<strong>Term</strong> was not deleted because it is in use on one or more licenses.",
-  "terms.callout.save.error": "There was an error saving the term. {error}",
-  "terms.callout.save.success": "Term successfully saved.",
+  "terms.callout.delete.error": "There was an error deleting term {name}: {error}",
+  "terms.callout.delete.success": "<strong>Term deleted:</strong> {name}",
+  "terms.callout.delete.termInUse": "<strong>Term</strong> {name} was not deleted because it is in use on one or more licenses.",
+  "terms.callout.save.error": "There was an error saving term {name}: {error}",
+  "terms.callout.save.success": "<strong>Term saved:</strong> {name}",
   "terms.optionalTerms": "Optional terms",
   "terms.primaryTerms": "Primary terms",
 

--- a/translations/ui-licenses/en.json
+++ b/translations/ui-licenses/en.json
@@ -25,6 +25,10 @@
   "amendments.amendmentInfo": "Amendment information",
   "amendments.update": "Update amendment",
 
+  "amendments.delete.confirmLabel": "Delete",
+  "amendments.delete.confirmHeading": "Delete amendment",
+  "amendments.delete.confirmMessage": "Amendment <strong>{name}</strong> will be <strong>deleted</strong>.",
+
   "coreDocs.add": "Add core document",
   "coreDocs.none": "No core documents have been added.",
   "coreDocs.removeCoreDoc": "Remove core document",

--- a/translations/ui-licenses/en_US.json
+++ b/translations/ui-licenses/en_US.json
@@ -81,9 +81,9 @@
     "edit": "Edit",
     "section.supplementaryDocuments": "Supplementary documents",
     "terms.count": "{count, number} saved {count, plural, one {term} other {terms}}",
-    "terms.callout.delete.error": "There was an error deleting the term. {error}",
-    "terms.callout.delete.success": "Term successfully deleted.",
-    "terms.callout.delete.termInUse": "<strong>Term</strong> was not deleted because it is in use on one or more licenses.",
-    "terms.callout.save.error": "There was an error saving the term. {error}",
-    "terms.callout.save.success": "Term successfully saved."
+    "terms.callout.delete.error": "There was an error deleting term {name}: {error}",
+    "terms.callout.delete.success": "<strong>Term deleted:</strong> {name}",
+    "terms.callout.delete.termInUse": "<strong>Term</strong> {name} was not deleted because it is in use on one or more licenses.",
+    "terms.callout.save.error": "There was an error saving term {name}: {error}",
+    "terms.callout.save.success": "<strong>Term saved:</strong> {name}"
 }


### PR DESCRIPTION
Callouts have been added upon creation/deletion/updating of licenses/amendments using the new stripes `CalloutContext`. For this to work, stripes dependencies will have to be updated across the board. I've not done that in this PR, because it's a little outside of the scope of this issue and spans several applications.

In addition, modals have been added when deleting amendments.