### PR TITLE
Fixed Contacts isEmpty message

### DIFF
--- a/src/components/viewSections/LicenseInternalContacts.js
+++ b/src/components/viewSections/LicenseInternalContacts.js
@@ -47,7 +47,7 @@ export default class LicenseInternalContacts extends React.Component {
         displayWhenClosed={this.renderBadge()}
         displayWhenOpen={this.renderBadge()}
         id={id}
-        label={<FormattedMessage id="ui-agreements.agreements.internalContacts" />}
+        label={<FormattedMessage id="ui-licenses.emptyAccordion.internalContacts" />}
         onToggle={onToggle}
         open={open}
       >


### PR DESCRIPTION
Fix for a bug I saw where the wrong translation ID was being used for internal contacts.