### PR TITLE
ERM-748: Added ability to delete licenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-licenses
 
+## 3.8.0 IN PROGRESS
+* Added permission set and ability to delete licenses. ERM-748
+
 ## 3.7.0 2020-03-11
 * Switched to using `<FormattedUTCDate>` from Stripes. ERM-635
 * Switched to using `<Spinner>` from Stripes. ERM-635

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/licenses",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "ERM License functionality for Stripes",
   "main": "src/index.js",
   "repository": "",
@@ -117,6 +117,7 @@
       {
         "permissionName": "ui-licenses.licenses.delete",
         "displayName": "Licenses: Delete licenses",
+        "visible": true,
         "subPermissions": [
           "ui-licenses.licenses.view",
           "licenses.licenses.item.delete"

--- a/src/routes/EditLicenseRoute.js
+++ b/src/routes/EditLicenseRoute.js
@@ -60,6 +60,7 @@ class EditLicenseRoute extends React.Component {
         return query ? { query } : {};
       },
       fetch: props => !!props.stripes.hasInterface('users', '15.0'),
+      permissionsRequired: 'users.collection.get',
       records: 'users',
     },
   });

--- a/src/routes/ViewLicenseRoute.js
+++ b/src/routes/ViewLicenseRoute.js
@@ -3,12 +3,14 @@ import PropTypes from 'prop-types';
 import { get, flatten, uniqBy } from 'lodash';
 import compose from 'compose-function';
 
-import { stripesConnect } from '@folio/stripes/core';
+import { CalloutContext, stripesConnect } from '@folio/stripes/core';
 import { withTags } from '@folio/stripes/smart-components';
 import { Tags } from '@folio/stripes-erm-components';
+import SafeHTMLMessage from '@folio/react-intl-safe-html';
 
 import withFileHandlers from './components/withFileHandlers';
 import View from '../components/License';
+import { urls } from '../components/utils';
 
 class ViewLicenseRoute extends React.Component {
   static manifest = Object.freeze({
@@ -39,6 +41,10 @@ class ViewLicenseRoute extends React.Component {
     license: {
       type: 'okapi',
       path: 'licenses/licenses/:{id}',
+      shouldRefresh: (resource, action) => {
+        if (resource.name !== 'license') return true;
+        return !action.meta.originatingActionType?.includes('DELETE');
+      },
     },
     linkedAgreements: {
       type: 'okapi',
@@ -92,6 +98,9 @@ class ViewLicenseRoute extends React.Component {
       interfaceRecord: PropTypes.shape({
         replace: PropTypes.func,
       }),
+      license: PropTypes.shape({
+        DELETE: PropTypes.func.isRequired,
+      }),
       query: PropTypes.shape({
         update: PropTypes.func.isRequired,
       }).isRequired,
@@ -116,6 +125,8 @@ class ViewLicenseRoute extends React.Component {
   static defaultProps = {
     handlers: {},
   }
+
+  static contextType = CalloutContext;
 
   getCompositeLicense = () => {
     const { resources } = this.props;
@@ -176,6 +187,26 @@ class ViewLicenseRoute extends React.Component {
     this.props.history.push(`/licenses${this.props.location.search}`);
   }
 
+  handleDelete = () => {
+    const { sendCallout } = this.context;
+    const { history, location, mutator } = this.props;
+    const license = this.getCompositeLicense();
+
+    if (license.linkedAgreements?.length) {
+      sendCallout({ type: 'error', timeout: 0, message: <SafeHTMLMessage id="ui-licenses.errors.noDeleteHasLinkedAgreements" /> });
+      return;
+    }
+
+    mutator.license.DELETE(license)
+      .then(() => {
+        history.push(`${urls.licenses()}${location.search}`);
+        sendCallout({ message: <SafeHTMLMessage id="ui-licenses.deletedLicense" values={{ name : license.name }} /> });
+      })
+      .catch(error => {
+        sendCallout({ type: 'error', timeout: 0, message: <SafeHTMLMessage id="ui-licenses.errors.noDeleteLicenseBackendError" values={{ message: error.message }} /> });
+      });
+  }
+
   handleFetchCredentials = (id) => {
     const { mutator } = this.props;
     mutator.interfaceRecord.replace({ id });
@@ -215,6 +246,7 @@ class ViewLicenseRoute extends React.Component {
         handlers={{
           ...handlers,
           onClose: this.handleClose,
+          onDelete: this.handleDelete,
           onFetchCredentials: this.handleFetchCredentials,
           onAmendmentClick: this.viewAmendment,
           onToggleHelper: this.handleToggleHelper,

--- a/src/routes/ViewLicenseRoute.js
+++ b/src/routes/ViewLicenseRoute.js
@@ -27,6 +27,7 @@ class ViewLicenseRoute extends React.Component {
         return query ? { query } : {};
       },
       fetch: props => !!props.stripes.hasInterface('organizations-storage.interfaces', '2.0'),
+      permissionsRequired: 'storage.interfaces.collection.get',
       records: 'interfaces',
     },
     interfacesCredentials: {
@@ -74,6 +75,7 @@ class ViewLicenseRoute extends React.Component {
         return query ? { query } : {};
       },
       fetch: props => !!props.stripes.hasInterface('users', '15.0'),
+      permissionsRequired: 'users.collection.get',
       records: 'users',
     },
     interfaceRecord: {},

--- a/src/routes/ViewLicenseRoute.js
+++ b/src/routes/ViewLicenseRoute.js
@@ -194,7 +194,7 @@ class ViewLicenseRoute extends React.Component {
     const { history, location, mutator } = this.props;
     const license = this.getCompositeLicense();
 
-    if (license.linkedAgreements?.length) {
+    if (license.linkedAgreements.length) {
       sendCallout({ type: 'error', timeout: 0, message: <SafeHTMLMessage id="ui-licenses.errors.noDeleteHasLinkedAgreements" /> });
       return;
     }

--- a/translations/ui-licenses/en.json
+++ b/translations/ui-licenses/en.json
@@ -15,7 +15,6 @@
   "create": "Create",
   "create.callout": "<strong>License created:</strong> {name}",
   "update.callout": "<strong>License updated:</strong> {name}",
-  "delete": "Delete",
   "editLicense": "Edit license",
   "edit": "Edit",
   "newLicense": "New license",
@@ -44,6 +43,11 @@
   "coreDocs.none": "No core documents have been added.",
   "coreDocs.removeCoreDoc": "Remove core document",
 
+  "delete": "Delete",
+  "deleteLicense": "Delete license",
+  "deletedLicense": "<strong>Deleted license:</strong> {name}",
+  "delete.confirmMessage": "License <strong>{name}</strong> and any attached amendments will be <strong>deleted</strong>.",
+
   "emptyAccordion.internalContacts": "No internal contacts for this license",
   "emptyAccordion.organizations": "No organizations for this license",
   "emptyAccordion.coreDocuments": "No core documents for this {type}",
@@ -55,6 +59,8 @@
   "errors.endDateGreaterThanStartDate": "End date must be after the start date.",
   "errors.multipleLicensors": "Only one Licensor per license is allowed.",
   "errors.termVisibilityWithoutValue": "A value must be set for this term in order to change visibility",
+  "errors.noDeleteHasLinkedAgreements": "<strong>License was not deleted</strong> because it is in use on one or more agreements.",
+  "errors.noDeleteLicenseBackendError": "<strong>License was not deleted:</strong> {message}",
 
   "export.csv.label": "Export selected as CSV ({count, number} items)",
 


### PR DESCRIPTION
- Makes the `Licenses: Delete licenses` permission set visible and assignable.
- Adds `Delete` dropdown button
- Front-end checks for whether the license has linked agreements. Disallows deletion if it does.
- Scoped `shouldRefresh` so that we don't attempt to try to fetch an `license` resource that was just deleted. Uses functionality added in https://github.com/folio-org/stripes-connect/pull/133