### PR TITLE
Fixes bug when Dates are not saved as entered when tenant timezone is ahead of UTC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-licenses
 
+## 5.1.0 In Progress
+* Added optionalOkapiInterfaces to package.json. ERM-940
+
 ##  5.0.0 2020-10-15
 * Added ability to set and view notes on organizations. ERM-967
 * Retrieve upto 100 results from users endpoint. ERM-980

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/licenses",
-  "version": "5.0.0",
+  "version": "5.1.0",
   "description": "ERM License functionality for Stripes",
   "main": "src/index.js",
   "repository": "",
@@ -85,8 +85,11 @@
     "home": "/licenses",
     "queryResource": "query",
     "okapiInterfaces": {
-      "licenses": "1.0 2.0 3.0",
-      "organizations-storage.interfaces": "2.0",
+      "licenses": "1.0 2.0 3.0"
+    },
+    "optionalOkapiInterfaces": {
+      "order-lines": "1.0",
+      "organizations-storage.interfaces": "1.0 2.0",
       "users": "13.0 14.0 15.0"
     },
     "stripesDeps": [

--- a/src/components/formSections/AmendmentFormInfo.js
+++ b/src/components/formSections/AmendmentFormInfo.js
@@ -12,7 +12,6 @@ import {
   TextArea,
   TextField,
 } from '@folio/stripes/components';
-import { parseDateOnlyString } from '../utils';
 
 class AmendmentFormInfo extends React.Component {
   static propTypes = {
@@ -84,7 +83,7 @@ class AmendmentFormInfo extends React.Component {
               label={<FormattedMessage id="ui-licenses.prop.startDate" />}
               name="startDate" // Lets us pass an empty string instead of `undefined`
               parse={v => v}
-              parser={parseDateOnlyString}
+              timeZone="UTC"
             />
           </Col>
           <Col md={5} xs={10}>
@@ -96,7 +95,7 @@ class AmendmentFormInfo extends React.Component {
               label={<FormattedMessage id="ui-licenses.prop.endDate" />}
               name="endDate"
               parse={v => v} // Lets us pass an empty string instead of `undefined`
-              parser={parseDateOnlyString}
+              timeZone="UTC"
               validate={this.validateEndDate}
             />
           </Col>

--- a/src/components/formSections/LicenseFormInfo.js
+++ b/src/components/formSections/LicenseFormInfo.js
@@ -15,8 +15,6 @@ import {
   TextField,
 } from '@folio/stripes/components';
 
-import { parseDateOnlyString } from '../utils';
-
 export default class LicenseFormInfo extends React.Component {
   static propTypes = {
     data: PropTypes.shape({
@@ -94,7 +92,7 @@ export default class LicenseFormInfo extends React.Component {
               label={<FormattedMessage id="ui-licenses.prop.startDate" />}
               name="startDate"
               parse={v => v} // Lets us pass an empty string instead of `undefined`
-              parser={parseDateOnlyString}
+              timeZone="UTC"
             />
           </Col>
           <Col md={5} xs={10}>
@@ -106,7 +104,7 @@ export default class LicenseFormInfo extends React.Component {
               label={<FormattedMessage id="ui-licenses.prop.endDate" />}
               name="endDate"
               parse={v => v} // Lets us pass an empty string instead of `undefined`
-              parser={parseDateOnlyString}
+              timeZone="UTC"
               validate={this.validateEndDate}
             />
           </Col>

--- a/src/components/utils/index.js
+++ b/src/components/utils/index.js
@@ -1,3 +1,2 @@
 export { default as formatNoteReferrer } from './formatNoteReferrer';
-export { default as parseDateOnlyString } from './parseDateOnlyString';
 export { default as urls } from './urls';

--- a/src/components/utils/parseDateOnlyString.js
+++ b/src/components/utils/parseDateOnlyString.js
@@ -1,7 +1,0 @@
-import moment from 'moment';
-
-const parseDateOnlyString = (value, _timeZone, dateFormat) => {
-  return (!value || value === '') ? value : moment(value).format(dateFormat);
-};
-
-export default parseDateOnlyString;


### PR DESCRIPTION
See [comment](https://github.com/folio-org/ui-agreements/pull/658#issue-514364687)