### PR TITLE
DO NOT MERGE UIU-2087 Fix Note Edit Page - doesn't return to record page after click on 'Save&Close'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-licenses
 
 ## 6.1.0 In progress
+* Fix Note Edit Page - doesn't return to record page after click on 'Save&Close'. UIU-2087
 
 ## 6.0.0 2021-03-17
 * Upgrade to Stripes 6.0

--- a/src/routes/NoteEditRoute.js
+++ b/src/routes/NoteEditRoute.js
@@ -4,7 +4,7 @@ import PropTypes from 'prop-types';
 
 import { NoteEditPage } from '@folio/stripes/smart-components';
 
-import { formatNoteReferrer, urls } from '../components/utils';
+import { formatNoteReferrer } from '../components/utils';
 
 export default class NoteEditRoute extends Component {
   static propTypes = {
@@ -17,24 +17,19 @@ export default class NoteEditRoute extends Component {
     }).isRequired,
   };
 
-  goToNoteView = () => {
-    const { history, location, match } = this.props;
-
-    history.replace({
-      pathname: urls.noteView(match.params.noteId),
-      state: location.state,
-    });
-  }
-
   render() {
-    const { location, match } = this.props;
+    const {
+      location,
+      match,
+      history,
+    } = this.props;
 
     return (
       <NoteEditPage
         domain="licenses"
         entityTypePluralizedTranslationKeys={{ license: 'ui-licenses.licensePlural' }}
         entityTypeTranslationKeys={{ license: 'ui-licenses.license' }}
-        navigateBack={this.goToNoteView}
+        navigateBack={history.goBack}
         noteId={match.params.noteId}
         paneHeaderAppIcon="license"
         referredEntityData={formatNoteReferrer(location.state)}


### PR DESCRIPTION
## Describe
Fix successful Note edit should redirect user to previous page

## Issues
[UIU-2087](https://issues.folio.org/browse/UIU-2087)