### PR TITLE
ERM-1898 upgrade react-intl-safe-html

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for ui-licenses
 
+## IN PROGRESS
+
+* Upgrade `@folio/react-intl-safe-html` for compatibility with `@folio/stripes` `v7`. ERM-1898
+
 ## 8.0.0 2021-10-07
 * Fixed bug with error on saving license if a change is made to the visibility (internal) flag of a primary property without populating it. ERM-1770
 * UX improvements for the Edit record pane title. ERM-1854

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "sinon": "^9.0.0"
   },
   "dependencies": {
-    "@folio/react-intl-safe-html": "^2.0.0",
+    "@folio/react-intl-safe-html": "^3.1.0",
     "@folio/stripes-erm-components": "^6.0.0",
     "@rehooks/local-storage": "2.4.0",
     "compose-function": "^3.0.3",


### PR DESCRIPTION
Upgrade `@folio/react-intl-safe-html` for compatibility with
`@folio/stripes` `v7` (react 17, react-intl 5).

Refs [ERM-1898](https://issues.folio.org/browse/ERM-1898), [STRIPES-769](https://issues.folio.org/browse/STRIPES-769)