### PR TITLE
fix: delete failure callout

### DIFF
--- a/src/settings/components/LicensesCustomProperties.js
+++ b/src/settings/components/LicensesCustomProperties.js
@@ -39,7 +39,8 @@ const LicensesCustomProperties = () => {
     retired: <FormattedMessage id="ui-licenses.terms.retired" />,
     primaryRetired: <FormattedMessage id="ui-licenses.terms.primaryRetired" />,
     ctx: <FormattedMessage id="ui-licenses.terms.category" />,
-    category: <FormattedMessage id="ui-licenses.terms.pickList" />
+    category: <FormattedMessage id="ui-licenses.terms.pickList" />,
+    deleteError: (error, custProp) => (<FormattedMessage id="ui-licenses.terms.deleteError" values={{ label: custProp?.label, error }} />)
   };
 
   const helpPopovers = {

--- a/translations/ui-licenses/en.json
+++ b/translations/ui-licenses/en.json
@@ -213,6 +213,7 @@
   "terms.primaryRetired": "A term cannot be both primary and deprecated",
   "terms.category": "Category",
   "terms.pickList": "Pick list",
+  "terms.deleteError": "There was an error deleting term: <strong>{label}</strong>. {error}",
 
   "term.editModal": "Edit term",
   "term.newModal": "New term",


### PR DESCRIPTION
Added translation labelOverride to CustomPropertiesSettings so that we surface deletion failures to the users again, and with a message specific to licenses.

ERM-2204