### PR TITLE
fix: Filters now update after refdata label changes

### DIFF
--- a/src/components/LicenseFilters/LicenseFilters.js
+++ b/src/components/LicenseFilters/LicenseFilters.js
@@ -1,5 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import isEqual from 'lodash/isEqual';
+
 import { FormattedMessage, useIntl } from 'react-intl';
 
 import { Accordion, AccordionSet, FilterAccordionHeader, Selection } from '@folio/stripes/components';
@@ -28,7 +30,7 @@ export default function LicenseFilters({ activeFilters, data, filterHandlers }) 
     const newState = {};
     FILTERS.forEach(filter => {
       const values = data[`${filter}Values`];
-      if (values.length !== filterState[filter]?.length) {
+      if (!isEqual(values, filterState[filter])) {
         newState[filter] = values;
       }
     });


### PR DESCRIPTION
Previously we were using the length of the refdata list to know when to redraw. Swapping that out for a lodash `isEqual` allows for a more complicated check, including embedded labels.

ERM-2205