### PR TITLE
fix: Duplicating an agreement line

### DIFF
--- a/src/routes/EditAmendmentRoute.js
+++ b/src/routes/EditAmendmentRoute.js
@@ -44,7 +44,7 @@ const EditAmendmentRoute = ({
     history.push(`/licenses/${licenseId}/amendments/${amendmentId}${location.search}`);
   };
 
-  const { data: license = {}, isLoading: isLicenseLoading } = useQuery(
+  const { data: license = {}, isFetching: isLicenseLoading } = useQuery(
     [LICENSE_ENDPOINT(licenseId), 'getLicense'],
     () => ky.get(LICENSE_ENDPOINT(licenseId)).json()
   );
@@ -71,6 +71,12 @@ const EditAmendmentRoute = ({
 
   const getInitialValues = () => {
     const initialValues = cloneDeep(selectedAmendment);
+    // After a cloned amendment we need to wait for the license to refetch to obtain its information
+    // Null safety this return while we wait for the license to refetch
+    if (!initialValues) {
+      return ({});
+    }
+
     const {
       status = {},
       supplementaryDocs = [],
@@ -95,6 +101,7 @@ const EditAmendmentRoute = ({
         handleClose();
       });
   };
+
 
   return (
     <Form

--- a/src/routes/ViewAmendmentRoute/ViewAmendmentRoute.js
+++ b/src/routes/ViewAmendmentRoute/ViewAmendmentRoute.js
@@ -62,7 +62,7 @@ const ViewAmendmentRoute = ({
     data: license = {},
     isLoading: isLicenseLoading
   } = useQuery(
-    [licensePath, 'ui-licenses', 'ViewAmendmentRoute', 'getLicense'],
+    [licensePath, 'getLicense'],
     () => ky.get(licensePath).json(),
     {
       enabled: !!licenseId
@@ -117,6 +117,9 @@ const ViewAmendmentRoute = ({
   const { mutateAsync: cloneAmendment } = useMutation(
     [`${amendmentPath}/clone`, 'ui-licenses', 'ViewAmendmentRoute', 'cloneAmendment'],
     (cloneableProperties) => ky.post(`${amendmentPath}/clone`, { json: cloneableProperties }).then(response => {
+      // Make sure we refetch the license after we've added an amendment
+      queryClient.invalidateQueries(LICENSE_ENDPOINT(licenseId));
+
       if (response.ok) {
         return response.text(); // Parse it as text
       } else {


### PR DESCRIPTION
Duplicating an amendment was previously not causing the associated license to refetch, meaning that when it attempted to render the amendment form, the logic in place that figures out which amendment is selected (Since they don't currently have a separate endpoint) was unable to identify the new one, and so the form was attempting in turn to try to find the status of an undefined object. Added in some null safeties and a check that the license isn't currently "fetching" (isFetching for react-query will be true for subsequent fetches, isLoading will not)

ERM-2224