### PR TITLE
fix: Query Namespacing

### DIFF
--- a/src/routes/ViewAmendmentRoute/ViewAmendmentRoute.js
+++ b/src/routes/ViewAmendmentRoute/ViewAmendmentRoute.js
@@ -74,6 +74,7 @@ const ViewAmendmentRoute = ({
     results: linkedAgreements = [],
   } = useBatchedFetch({
     batchSize: RECORDS_PER_REQUEST,
+    nsArray: ['ERM', 'License', licenseId, 'LinkedAgreements'],
     path: LINKED_AGREEMENTS_ENDPOINT(licenseId),
   });
 

--- a/src/routes/ViewLicenseRoute/ViewLicenseRoute.js
+++ b/src/routes/ViewLicenseRoute/ViewLicenseRoute.js
@@ -69,6 +69,7 @@ const ViewLicenseRoute = ({
     results: linkedAgreements,
   } = useBatchedFetch({
     batchSize: RECORDS_PER_REQUEST,
+    nsArray: ['ERM', 'License', licenseId, 'LinkedAgreements'],
     path: LINKED_AGREEMENTS_ENDPOINT(licenseId),
   });
 


### PR DESCRIPTION
Tweaked namespacing of linkedAgreement fetches so that they fall in line with the convention laid out in ERM-2227. This allows Agreements then to invalidate those without caring about the endpoint Licenses uses

Also refactored LicenseAgreement to functional and changed how it decides whether linkedAgreements have changed, to avoid cached data showing up in table when we don't want it

ERM-2225, ERM-2227