### PR TITLE
build: Kint-Components dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
   },
   "dependencies": {
     "@folio/stripes-erm-components": "^6.2.0",
-    "@k-int/stripes-kint-components": "^2.7.0",
+    "@k-int/stripes-kint-components": "^2.8.2",
     "@folio/stripes-testing": "^4.2.0",
     "@rehooks/local-storage": "2.4.4",
     "@testing-library/react": "^12.1.2",


### PR DESCRIPTION
Bumped kint-components dependency to 2.8.2 to ensure we get the EBSCO-safe error handling in settings

ERM-2282