### PR TITLE
chore: Tags invalidation comment

### DIFF
--- a/src/routes/ViewLicenseRoute/ViewLicenseRoute.js
+++ b/src/routes/ViewLicenseRoute/ViewLicenseRoute.js
@@ -48,6 +48,7 @@ const ViewLicenseRoute = ({
     },
     isLoading: isLicenseLoading
   } = useQuery(
+    // NOTE Used as invalidate link for tags below!
     [licensePath, 'getLicense'],
     () => ky.get(licensePath).json(),
     {


### PR DESCRIPTION
Currently the Tags component relies on the invalidation for licenses being the same as its fetch endpoint, added comment to this effect

ERM-2297