### PR TITLE
ERM-2366: Core documents for a License shouldn't display a category

### DIFF
--- a/src/components/viewSections/CoreDocs.js
+++ b/src/components/viewSections/CoreDocs.js
@@ -25,6 +25,7 @@ const CoreDocs = ({
       <DocumentCard
         key={doc.id}
         hasDownloadPerm={stripes.hasPerm('ui-licenses.licenses.file.download')}
+        hideCategory
         onDownloadFile={handleDownloadFile}
         {...doc}
       />


### PR DESCRIPTION
fix: CoreDocs Category

Used new `hideCategory` prop on DocumentCard to enable the hiding of Category KeyValue in certain circumstances, namely in the Core Doc use case

ERM-2366