### PR TITLE
ERM-2379: @folio/stripes-testing is incorrectly listed as a direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
     "typescript": "^2.8.0"
   },
   "dependencies": {
-    "@folio/stripes-testing": "^4.2.0",
     "@k-int/stripes-kint-components": "^3.0.2",
     "@rehooks/local-storage": "2.4.4",
     "compose-function": "^3.0.3",


### PR DESCRIPTION
build: stripes-testing

Removed stripes-testing as a direct dependency

ERM-2379