### PR TITLE
fix: LicenseFilters

### DIFF
--- a/src/components/Licenses/Licenses.js
+++ b/src/components/Licenses/Licenses.js
@@ -176,12 +176,12 @@ const Licenses = ({
                           </Icon>
                         </Button>
                       </div>
-                      <LicenseFilters
-                        activeFilters={activeFilters.state}
-                        data={data}
-                        filterHandlers={getFilterHandlers()}
-                      />
                     </form>
+                    <LicenseFilters
+                      activeFilters={activeFilters.state}
+                      data={data}
+                      filterHandlers={getFilterHandlers()}
+                    />
                   </Pane>
                 }
                 <Pane


### PR DESCRIPTION
Moved LicenseFilters outside of the <form> rendered for the Search field. This stops the issue where CustomPropertiesFilters was throwing a console error due to a nested <form> component

ERM-2398