### PR TITLE
ERM-2973: Replace naive fetch hooks with parallelised ones (and deprecate)

### DIFF
--- a/src/components/Licenses/Licenses.test.js
+++ b/src/components/Licenses/Licenses.test.js
@@ -89,6 +89,6 @@ describe('Licenses', () => {
   });
 
   test('renders the Search Licenses searchbox', async () => {
-    await SearchField().exists()
+    await SearchField().exists();
   });
 });

--- a/src/routes/EditLicenseRoute/EditLicenseRoute.js
+++ b/src/routes/EditLicenseRoute/EditLicenseRoute.js
@@ -7,7 +7,7 @@ import { cloneDeep, get } from 'lodash';
 import { useMutation, useQuery, useQueryClient } from 'react-query';
 
 import { CalloutContext, useOkapiKy, useStripes } from '@folio/stripes/core';
-import { getRefdataValuesByDesc, useUsers } from '@folio/stripes-erm-components';
+import { getRefdataValuesByDesc, useChunkedUsers } from '@folio/stripes-erm-components';
 
 import Form from '../../components/LicenseForm';
 import NoPermissions from '../../components/NoPermissions';
@@ -72,7 +72,7 @@ const EditLicenseRoute = ({
   );
 
   // Users
-  const { data: { users = [] } = {} } = useUsers(license?.contacts?.filter(c => c.user)?.map(c => c.user));
+  const { users } = useChunkedUsers(license?.contacts?.filter(c => c.user)?.map(c => c.user) ?? []);
 
   const getInitialValues = () => {
     const initialValues = cloneDeep(license);

--- a/src/routes/ViewAmendmentRoute/ViewAmendmentRoute.js
+++ b/src/routes/ViewAmendmentRoute/ViewAmendmentRoute.js
@@ -6,7 +6,7 @@ import { FormattedMessage } from 'react-intl';
 
 import { CalloutContext, useOkapiKy, useStripes } from '@folio/stripes/core';
 import { ConfirmationModal } from '@folio/stripes/components';
-import { useBatchedFetch } from '@folio/stripes-erm-components';
+import { useParallelBatchFetch } from '@folio/stripes-erm-components';
 
 import DuplicateAmendmentModal from '../../components/DuplicateAmendmentModal';
 import View from '../../components/Amendment';
@@ -14,7 +14,6 @@ import View from '../../components/Amendment';
 import { errorTypes } from '../../constants';
 import { AMENDMENT_ENDPOINT, LICENSE_ENDPOINT, LINKED_AGREEMENTS_ENDPOINT } from '../../constants/endpoints';
 
-const RECORDS_PER_REQUEST = 100;
 const propTypes = {
   handlers: PropTypes.object,
   history: PropTypes.shape({
@@ -67,11 +66,10 @@ const ViewAmendmentRoute = ({
 
   // LinkedAgreements BATCH FETCH
   const {
-    results: linkedAgreements = [],
-  } = useBatchedFetch({
-    batchSize: RECORDS_PER_REQUEST,
-    nsArray: ['ERM', 'License', licenseId, 'LinkedAgreements'],
-    path: LINKED_AGREEMENTS_ENDPOINT(licenseId),
+    items: linkedAgreements = [],
+  } = useParallelBatchFetch({
+    generateQueryKey: ({ offset }) => ['ERM', 'License', licenseId, 'LinkedAgreements', offset],
+    endpoint: LINKED_AGREEMENTS_ENDPOINT(licenseId),
   });
 
   const getCompositeLicense = () => {


### PR DESCRIPTION
feat: Swap to parallel fetch hooks

Swapped over to use useParallelBatchFetch and useChunkedUsers instead of useBatchedFetch and useUsers

refs ERM-2973, ERM-2976, ERM-2977