### PR TITLE
ERM-3037: unlock @rehooks/local-storage from 2.4.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@k-int/stripes-kint-components": "^5.0.0",
-    "@rehooks/local-storage": "2.4.4",
+    "@rehooks/local-storage": "^2.4.4",
     "compose-function": "^3.0.3",
     "final-form": "^4.18.4",
     "final-form-arrays": "^3.0.1",


### PR DESCRIPTION
build: @rehooks/local-storage

Removed lock on @rehooks/local-storage

ERM-3037