### PR TITLE
ERM-3285: Fix permission on /licenses/files/{id}/raw in mod-licenses

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
         "description": "A user with this permission is able to download and view the content of License document files",
         "visible": true,
         "subPermissions": [
-          "licenses.files.item.download"
+          "licenses.files.item.download",
+          "licenses.files.view"
         ]
       },
       {


### PR DESCRIPTION
- Add licenses.files.view as a sub permission of ui-licenses.licenses.file.download in ui-licenses package.json 

MERGE AFTER https://github.com/folio-org/mod-licenses/pull/267/files