### PR TITLE
chore: Release 11.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for ui-licenses
 
+## 11.0.2 2024-07-05
+  * ERM-3285 Fix permission on /licenses/files/{id}/raw in mod-licenses
+
 ## 11.0.1 2024-04-19
   * ERM-3182 Scrolling content in license view pane can overlap header
   * Translations

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/licenses",
-  "version": "11.0.1",
+  "version": "11.0.2",
   "description": "ERM License functionality for Stripes",
   "main": "src/index.js",
   "repository": "",

--- a/package.json
+++ b/package.json
@@ -115,7 +115,8 @@
         "description": "A user with this permission is able to download and view the content of License document files",
         "visible": true,
         "subPermissions": [
-          "licenses.files.item.download"
+          "licenses.files.item.download",
+          "licenses.files.view"
         ]
       },
       {


### PR DESCRIPTION
Added changelog section and bumped version number to 11.0.2

- ERM-3285 Fix permission on /licenses/files/{id}/raw in mod-licenses

ERM-3293