### PR TITLE
build: Removed nswapi resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -223,8 +223,5 @@
         "title": "Amendment"
       }
     ]
-  },
-  "resolutions": {
-    "nwsapi": "2.2.13"
-  }  
+  }
 }


### PR DESCRIPTION
Removed previously required nwsapi resolution pinning version to 2.2.13, issues caused have been resolved as of 2.2.16 release