### PR TITLE
ERM-4014 Change default `headingLevel` in meta section header to `3`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change history for ui-licenses
 
 ## 12.2.0 IN PROGRESS
+  * ERM-4014: Change default `headingLevel` in meta section header to `3`
 
 ## 12.1.0 2026-04-17
   * ERM-3979: Make "Duplicate" option in Amendment actions menu inactive and greyed out when parent license cannot be edited via access control

--- a/src/components/viewSections/AmendmentInfo/AmendmentInfo.js
+++ b/src/components/viewSections/AmendmentInfo/AmendmentInfo.js
@@ -14,6 +14,8 @@ import {
 
 import { LicenseEndDate } from '@folio/stripes-erm-components';
 
+import { DEFAULT_META_SECTION_HEADING_LEVEL } from '../../../constants';
+
 const propTypes = {
   amendment: PropTypes.shape({
     dateCreated: PropTypes.string,
@@ -47,6 +49,7 @@ const AmendmentInfo = ({ amendment }) => {
       <MetaSection
         contentId="amendmentInfoRecordMetaContent"
         createdDate={amendment.dateCreated}
+        headingLevel={DEFAULT_META_SECTION_HEADING_LEVEL}
         hideSource
         id="amendmentInfoRecordMeta"
         lastUpdatedDate={amendment.lastUpdated}

--- a/src/components/viewSections/LicenseInfo/LicenseInfo.js
+++ b/src/components/viewSections/LicenseInfo/LicenseInfo.js
@@ -11,6 +11,8 @@ import {
   Row
 } from '@folio/stripes/components';
 
+import { DEFAULT_META_SECTION_HEADING_LEVEL } from '../../../constants';
+
 class LicenseInfo extends React.Component {
   static propTypes = {
     license: PropTypes.object,
@@ -38,6 +40,7 @@ class LicenseInfo extends React.Component {
         <MetaSection
           contentId="licenseInfoRecordMetaContent"
           createdDate={license.dateCreated}
+          headingLevel={DEFAULT_META_SECTION_HEADING_LEVEL}
           hideSource
           id="licenseInfoRecordMeta"
           lastUpdatedDate={license.lastUpdated}

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -4,3 +4,4 @@ export { default as resultCount } from './resultCount';
 export { default as amendmentContentOptions } from './amendmentContentOptions';
 export { default as licenseContentOptions } from './licenseContentOptions';
 export * from './endpoints';
+export * from './metasection';

--- a/src/constants/metasection.js
+++ b/src/constants/metasection.js
@@ -1,0 +1,1 @@
+export const DEFAULT_META_SECTION_HEADING_LEVEL = 3;


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/ERM-4014

> In Agreements, Licenses, Serials Management, OA, we do not normally have a heading between our view pane header and our metadata section. This leads to a jump in header from H2 to H4 causing accessibility issues. This ticket is to change the default heading level for the metadata section to be H3 avoiding this error