### PR TITLE
ERM-4076, Agreements and Licenses UIs should only do access checks if there are enabled engines

### DIFF
--- a/src/routes/CreateLicenseRoute/CreateLicenseRoute.js
+++ b/src/routes/CreateLicenseRoute/CreateLicenseRoute.js
@@ -18,7 +18,7 @@ import View from '../../components/LicenseForm';
 import NoPermissions from '../../components/NoPermissions';
 import urls from '../../components/utils/urls';
 
-import { LICENSES_ENDPOINT } from '../../constants';
+import { LICENSES_ENDPOINT, LICENSE_ACCESSCONTROL_ENDPOINT } from '../../constants';
 import { useLicenseRefdata } from '../../hooks';
 
 const [
@@ -48,6 +48,7 @@ const CreateLicenseRoute = ({
   const hasPerms = stripes.hasPerm('ui-licenses.licenses.edit');
 
   const accessControlData = useGetAccess({
+    accessControlEndpoint: LICENSE_ACCESSCONTROL_ENDPOINT,
     resourceEndpoint: LICENSES_ENDPOINT,
     queryNamespaceGenerator: (_restriction, canDo) => ['ERM', 'License', canDo]
   });

--- a/src/routes/EditLicenseRoute/EditLicenseRoute.js
+++ b/src/routes/EditLicenseRoute/EditLicenseRoute.js
@@ -15,7 +15,6 @@ import {
   useChunkedUsers,
   useGetAccess,
   useClaim,
-  usePolicies,
   isEqualClaimPolicies,
 } from '@folio/stripes-erm-components';
 
@@ -54,14 +53,15 @@ const EditLicenseRoute = ({
     accessControlEndpoint: LICENSE_ACCESSCONTROL_ENDPOINT,
     resourceEndpoint: LICENSES_ENDPOINT,
     resourceId: licenseId,
-    queryNamespaceGenerator: (_restriction, canDo) => ['ERM', 'License', licenseId, canDo]
+    queryNamespaceGenerator: (_restriction, canDo) => ['ERM', 'License', licenseId, canDo],
+    policiesQueryNamespaceGenerator: () => ['ERM', 'License', licenseId, 'policies'],
   });
 
   const {
     canRead,
     canEdit,
-    doAccessControl,
     isLoading: isAccessControlLoading,
+    policies
   } = accessControlData;
   const refdata = useLicenseRefdata({
     desc: [
@@ -86,13 +86,6 @@ const EditLicenseRoute = ({
   );
 
   const { claim } = useClaim({ resourceEndpoint: LICENSES_ENDPOINT });
-
-  const { policies } = usePolicies({
-    resourceEndpoint: LICENSES_ENDPOINT,
-    resourceId: licenseId,
-    doAccessControl,
-    queryNamespaceGenerator: () => ['ERM', 'License', licenseId, 'policies'],
-  });
 
   const { mutateAsync: putLicense } = useMutation(
     [LICENSE_ENDPOINT(licenseId), 'putLicense'],

--- a/src/routes/EditLicenseRoute/EditLicenseRoute.js
+++ b/src/routes/EditLicenseRoute/EditLicenseRoute.js
@@ -22,7 +22,7 @@ import {
 import Form from '../../components/LicenseForm';
 import NoPermissions from '../../components/NoPermissions';
 
-import { LICENSE_ENDPOINT, LICENSES_ENDPOINT } from '../../constants';
+import { LICENSE_ENDPOINT, LICENSES_ENDPOINT, LICENSE_ACCESSCONTROL_ENDPOINT } from '../../constants';
 import { useLicenseRefdata } from '../../hooks';
 
 const [
@@ -51,6 +51,7 @@ const EditLicenseRoute = ({
   const queryClient = useQueryClient();
 
   const accessControlData = useGetAccess({
+    accessControlEndpoint: LICENSE_ACCESSCONTROL_ENDPOINT,
     resourceEndpoint: LICENSES_ENDPOINT,
     resourceId: licenseId,
     queryNamespaceGenerator: (_restriction, canDo) => ['ERM', 'License', licenseId, canDo]
@@ -59,7 +60,9 @@ const EditLicenseRoute = ({
   const {
     canRead,
     canEdit,
-    isLoading: isAccessControlLoading
+    doAccessControl,
+    isLoading: isAccessControlLoading,
+    isDoAccessControlLoading,
   } = accessControlData;
   const refdata = useLicenseRefdata({
     desc: [
@@ -88,6 +91,8 @@ const EditLicenseRoute = ({
   const { policies } = usePolicies({
     resourceEndpoint: LICENSES_ENDPOINT,
     resourceId: licenseId,
+    doAccessControl,
+    isDoAccessControlLoading,
     queryNamespaceGenerator: () => ['ERM', 'License', licenseId, 'policies'],
   });
 

--- a/src/routes/EditLicenseRoute/EditLicenseRoute.js
+++ b/src/routes/EditLicenseRoute/EditLicenseRoute.js
@@ -62,7 +62,6 @@ const EditLicenseRoute = ({
     canEdit,
     doAccessControl,
     isLoading: isAccessControlLoading,
-    isDoAccessControlLoading,
   } = accessControlData;
   const refdata = useLicenseRefdata({
     desc: [
@@ -92,7 +91,6 @@ const EditLicenseRoute = ({
     resourceEndpoint: LICENSES_ENDPOINT,
     resourceId: licenseId,
     doAccessControl,
-    isDoAccessControlLoading,
     queryNamespaceGenerator: () => ['ERM', 'License', licenseId, 'policies'],
   });
 

--- a/src/routes/ViewAmendmentRoute/ViewAmendmentRoute.js
+++ b/src/routes/ViewAmendmentRoute/ViewAmendmentRoute.js
@@ -77,7 +77,6 @@ const ViewAmendmentRoute = ({
     canRead,
     doAccessControl,
     isLoading: isAccessControlLoading,
-    isDoAccessControlLoading,
   } = accessControlData;
 
   const { data: amendment = {} } = useQuery(
@@ -118,7 +117,6 @@ const ViewAmendmentRoute = ({
     resourceEndpoint: AMENDMENTS_ENDPOINT,
     resourceId: amendmentId,
     doAccessControl,
-    isDoAccessControlLoading,
     // While this is note the pattern we use for Amendment fetches, this is
     // because in this case Amendment policies _rely_ on License policies,
     // so a refresh should affect both

--- a/src/routes/ViewAmendmentRoute/ViewAmendmentRoute.js
+++ b/src/routes/ViewAmendmentRoute/ViewAmendmentRoute.js
@@ -23,6 +23,7 @@ import {
   LICENSE_ENDPOINT,
   LINKED_AGREEMENTS_ENDPOINT,
   AMENDMENTS_ENDPOINT,
+  LICENSE_ACCESSCONTROL_ENDPOINT
 } from '../../constants';
 import { urls as appUrls } from '../../components/utils';
 
@@ -66,6 +67,7 @@ const ViewAmendmentRoute = ({
   const amendmentPath = AMENDMENT_ENDPOINT(amendmentId);
 
   const accessControlData = useGetAccess({
+    accessControlEndpoint: LICENSE_ACCESSCONTROL_ENDPOINT,
     resourceEndpoint: AMENDMENTS_ENDPOINT,
     resourceId: amendmentId,
     queryNamespaceGenerator: (_restriction, canDo) => ['ERM', 'Amendment', amendmentId, canDo]
@@ -73,7 +75,9 @@ const ViewAmendmentRoute = ({
 
   const {
     canRead,
+    doAccessControl,
     isLoading: isAccessControlLoading,
+    isDoAccessControlLoading,
   } = accessControlData;
 
   const { data: amendment = {} } = useQuery(
@@ -113,6 +117,8 @@ const ViewAmendmentRoute = ({
   const { policies = [] } = usePolicies({
     resourceEndpoint: AMENDMENTS_ENDPOINT,
     resourceId: amendmentId,
+    doAccessControl,
+    isDoAccessControlLoading,
     // While this is note the pattern we use for Amendment fetches, this is
     // because in this case Amendment policies _rely_ on License policies,
     // so a refresh should affect both

--- a/src/routes/ViewAmendmentRoute/ViewAmendmentRoute.js
+++ b/src/routes/ViewAmendmentRoute/ViewAmendmentRoute.js
@@ -10,7 +10,6 @@ import {
   INVALID_JSON_ERROR,
   JSON_ERROR,
   useParallelBatchFetch,
-  usePolicies,
   useGetAccess,
   useErmHelperApp
 } from '@folio/stripes-erm-components';
@@ -70,12 +69,17 @@ const ViewAmendmentRoute = ({
     accessControlEndpoint: LICENSE_ACCESSCONTROL_ENDPOINT,
     resourceEndpoint: AMENDMENTS_ENDPOINT,
     resourceId: amendmentId,
-    queryNamespaceGenerator: (_restriction, canDo) => ['ERM', 'Amendment', amendmentId, canDo]
+    queryNamespaceGenerator: (_restriction, canDo) => ['ERM', 'Amendment', amendmentId, canDo],
+    // While this is note the pattern we use for Amendment fetches, this is
+    // because in this case Amendment policies _rely_ on License policies,
+    // so a refresh should affect both
+    policiesQueryNamespaceGenerator: () => ['ERM', 'License', licenseId, 'AmendmentPolicies', amendmentId],
+
   });
 
   const {
     canRead,
-    doAccessControl,
+    policies = [],
     isLoading: isAccessControlLoading,
   } = accessControlData;
 
@@ -112,16 +116,6 @@ const ViewAmendmentRoute = ({
       linkedAgreements,
     };
   };
-
-  const { policies = [] } = usePolicies({
-    resourceEndpoint: AMENDMENTS_ENDPOINT,
-    resourceId: amendmentId,
-    doAccessControl,
-    // While this is note the pattern we use for Amendment fetches, this is
-    // because in this case Amendment policies _rely_ on License policies,
-    // so a refresh should affect both
-    queryNamespaceGenerator: () => ['ERM', 'License', licenseId, 'AmendmentPolicies', amendmentId],
-  });
 
   const handleClose = () => {
     // If we're coming from amendments, go back to amendments, else go back to license view

--- a/src/routes/ViewLicenseRoute/ViewLicenseRoute.js
+++ b/src/routes/ViewLicenseRoute/ViewLicenseRoute.js
@@ -20,7 +20,12 @@ import {
 import View from '../../components/License';
 import { urls as appUrls } from '../../components/utils';
 
-import { LICENSE_ENDPOINT, LINKED_AGREEMENTS_ENDPOINT, LICENSES_ENDPOINT } from '../../constants';
+import {
+  LICENSE_ENDPOINT,
+  LINKED_AGREEMENTS_ENDPOINT,
+  LICENSES_ENDPOINT,
+  LICENSE_ACCESSCONTROL_ENDPOINT
+} from '../../constants';
 
 const ViewLicenseRoute = ({
   handlers = {},
@@ -43,14 +48,17 @@ const ViewLicenseRoute = ({
 
   // Access control fetch
   const accessControlData = useGetAccess({
+    accessControlEndpoint: LICENSE_ACCESSCONTROL_ENDPOINT,
     resourceEndpoint: LICENSES_ENDPOINT,
     resourceId: licenseId,
     queryNamespaceGenerator: (_restriction, canDo) => ['ERM', 'License', licenseId, canDo]
   });
 
   const {
-    isLoading: isAccessControlLoading,
     canRead,
+    doAccessControl,
+    isLoading: isAccessControlLoading,
+    isDoAccessControlLoading,
   } = accessControlData;
 
   // License fetch
@@ -97,6 +105,8 @@ const ViewLicenseRoute = ({
   const { policies = [] } = usePolicies({
     resourceEndpoint: LICENSES_ENDPOINT,
     resourceId: licenseId,
+    doAccessControl,
+    isDoAccessControlLoading,
     queryNamespaceGenerator: () => ['ERM', 'License', licenseId, 'policies'],
     queryOptions: {
       enabled: !isAccessControlLoading && !!canRead

--- a/src/routes/ViewLicenseRoute/ViewLicenseRoute.js
+++ b/src/routes/ViewLicenseRoute/ViewLicenseRoute.js
@@ -13,7 +13,6 @@ import {
   useInterfaces,
   useParallelBatchFetch,
   useErmHelperApp,
-  usePolicies,
   useGetAccess
 } from '@folio/stripes-erm-components';
 
@@ -51,13 +50,14 @@ const ViewLicenseRoute = ({
     accessControlEndpoint: LICENSE_ACCESSCONTROL_ENDPOINT,
     resourceEndpoint: LICENSES_ENDPOINT,
     resourceId: licenseId,
-    queryNamespaceGenerator: (_restriction, canDo) => ['ERM', 'License', licenseId, canDo]
+    queryNamespaceGenerator: (_restriction, canDo) => ['ERM', 'License', licenseId, canDo],
+    policiesQueryNamespaceGenerator: () => ['ERM', 'License', licenseId, 'policies'],
   });
 
   const {
     canRead,
-    doAccessControl,
     isLoading: isAccessControlLoading,
+    policies = []
   } = accessControlData;
 
   // License fetch
@@ -95,17 +95,6 @@ const ViewLicenseRoute = ({
   } = useParallelBatchFetch({
     generateQueryKey: ({ offset }) => ['ERM', 'License', licenseId, 'LinkedAgreements', offset],
     endpoint: LINKED_AGREEMENTS_ENDPOINT(licenseId),
-    queryOptions: {
-      enabled: !isAccessControlLoading && !!canRead
-    }
-  });
-
-  // Policies fetch
-  const { policies = [] } = usePolicies({
-    resourceEndpoint: LICENSES_ENDPOINT,
-    resourceId: licenseId,
-    doAccessControl,
-    queryNamespaceGenerator: () => ['ERM', 'License', licenseId, 'policies'],
     queryOptions: {
       enabled: !isAccessControlLoading && !!canRead
     }

--- a/src/routes/ViewLicenseRoute/ViewLicenseRoute.js
+++ b/src/routes/ViewLicenseRoute/ViewLicenseRoute.js
@@ -58,7 +58,6 @@ const ViewLicenseRoute = ({
     canRead,
     doAccessControl,
     isLoading: isAccessControlLoading,
-    isDoAccessControlLoading,
   } = accessControlData;
 
   // License fetch
@@ -106,7 +105,6 @@ const ViewLicenseRoute = ({
     resourceEndpoint: LICENSES_ENDPOINT,
     resourceId: licenseId,
     doAccessControl,
-    isDoAccessControlLoading,
     queryNamespaceGenerator: () => ['ERM', 'License', licenseId, 'policies'],
     queryOptions: {
       enabled: !isAccessControlLoading && !!canRead


### PR DESCRIPTION
Pass LICENSE_ACCESSCONTROL_ENDPOINT to useGetAccess in CreateLicenseRoute to ensure consistent access control behavior.